### PR TITLE
feat: make icon packages self-contained and add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,40 @@
+name: Publish npm packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Publish packages
+        run: |
+          for pkg in packages/*/; do
+            name=$(node -p "require('./${pkg}package.json').name")
+            version=$(node -p "require('./${pkg}package.json').version")
+            published=$(npm view "$name@$version" version 2>/dev/null || echo "")
+            if [ "$published" = "$version" ]; then
+              echo "Skipping $name@$version (already published)"
+            else
+              echo "Publishing $name@$version"
+              npm publish --workspace "$pkg"
+            fi
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/carbon/BaseIcon.astro
+++ b/packages/carbon/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/carbon/Icon.astro
+++ b/packages/carbon/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from '@iconify-json/carbon/icons.json';
 
 interface Props {

--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -7,10 +7,14 @@
     "./Icon.astro": "./Icon.astro"
   },
   "files": [
-    "Icon.astro"
+    "Icon.astro",
+    "BaseIcon.astro"
   ],
   "dependencies": {
     "@iconify-json/carbon": "^1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["carbon", "ibm", "icons", "iconify", "astro"],
   "license": "MIT"

--- a/packages/f5-brand/BaseIcon.astro
+++ b/packages/f5-brand/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/f5-brand/Icon.astro
+++ b/packages/f5-brand/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from './icons.json';
 
 interface Props {

--- a/packages/f5-brand/package.json
+++ b/packages/f5-brand/package.json
@@ -10,9 +10,13 @@
   },
   "files": [
     "Icon.astro",
+    "BaseIcon.astro",
     "icons.json",
     "svg/"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "f5",
     "icons",

--- a/packages/hashicorp-flight/BaseIcon.astro
+++ b/packages/hashicorp-flight/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/hashicorp-flight/Icon.astro
+++ b/packages/hashicorp-flight/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from './icons.json';
 
 interface Props {

--- a/packages/hashicorp-flight/package.json
+++ b/packages/hashicorp-flight/package.json
@@ -10,10 +10,14 @@
   },
   "files": [
     "Icon.astro",
+    "BaseIcon.astro",
     "icons.json"
   ],
   "dependencies": {
     "@hashicorp/flight-icons": "^4.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["hashicorp", "flight", "icons", "iconify", "astro"],
   "license": "MIT"

--- a/packages/lucide/BaseIcon.astro
+++ b/packages/lucide/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/lucide/Icon.astro
+++ b/packages/lucide/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from '@iconify-json/lucide/icons.json';
 
 interface Props {

--- a/packages/lucide/package.json
+++ b/packages/lucide/package.json
@@ -7,10 +7,14 @@
     "./Icon.astro": "./Icon.astro"
   },
   "files": [
-    "Icon.astro"
+    "Icon.astro",
+    "BaseIcon.astro"
   ],
   "dependencies": {
     "@iconify-json/lucide": "^1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["lucide", "icons", "iconify", "astro"],
   "license": "MIT"

--- a/packages/mdi/BaseIcon.astro
+++ b/packages/mdi/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/mdi/Icon.astro
+++ b/packages/mdi/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from '@iconify-json/mdi/icons.json';
 
 interface Props {

--- a/packages/mdi/package.json
+++ b/packages/mdi/package.json
@@ -7,10 +7,14 @@
     "./Icon.astro": "./Icon.astro"
   },
   "files": [
-    "Icon.astro"
+    "Icon.astro",
+    "BaseIcon.astro"
   ],
   "dependencies": {
     "@iconify-json/mdi": "^1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["mdi", "material-design", "icons", "iconify", "astro"],
   "license": "MIT"

--- a/packages/phosphor/BaseIcon.astro
+++ b/packages/phosphor/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/phosphor/Icon.astro
+++ b/packages/phosphor/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from '@iconify-json/ph/icons.json';
 
 interface Props {

--- a/packages/phosphor/package.json
+++ b/packages/phosphor/package.json
@@ -7,10 +7,14 @@
     "./Icon.astro": "./Icon.astro"
   },
   "files": [
-    "Icon.astro"
+    "Icon.astro",
+    "BaseIcon.astro"
   ],
   "dependencies": {
     "@iconify-json/ph": "^1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["phosphor", "icons", "iconify", "astro"],
   "license": "MIT"

--- a/packages/tabler/BaseIcon.astro
+++ b/packages/tabler/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/tabler/Icon.astro
+++ b/packages/tabler/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import BaseIcon from '../../shared/BaseIcon.astro';
+import BaseIcon from './BaseIcon.astro';
 import iconData from '@iconify-json/tabler/icons.json';
 
 interface Props {

--- a/packages/tabler/package.json
+++ b/packages/tabler/package.json
@@ -7,10 +7,14 @@
     "./Icon.astro": "./Icon.astro"
   },
   "files": [
-    "Icon.astro"
+    "Icon.astro",
+    "BaseIcon.astro"
   ],
   "dependencies": {
     "@iconify-json/tabler": "^1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": ["tabler", "icons", "iconify", "astro"],
   "license": "MIT"


### PR DESCRIPTION
## Summary
- Copy `BaseIcon.astro` into each of the 7 icon package directories so they are independently installable from npm
- Update `Icon.astro` imports from `../../shared/BaseIcon.astro` to `./BaseIcon.astro`
- Add `BaseIcon.astro` to each package's `files` array and add `publishConfig.access: public`
- Add `.github/workflows/npm-publish.yml` to publish packages on push to main

## Test plan
- [ ] Verify `npm pack --dry-run` includes `BaseIcon.astro` in each package
- [ ] Verify npm publish workflow triggers and succeeds after merge
- [ ] Verify `npm info @f5xc-salesdemos/icons-f5-brand` shows published package

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)