### PR TITLE
fix: rename npm scope from @f5xc-salesdemos to @robinmordasiewicz

### DIFF
--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-carbon",
+  "name": "@robinmordasiewicz/icons-carbon",
   "version": "0.1.0",
   "description": "Carbon Design icons with Astro component wrapper",
   "type": "module",

--- a/packages/f5-brand/package.json
+++ b/packages/f5-brand/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-f5-brand",
+  "name": "@robinmordasiewicz/icons-f5-brand",
   "version": "0.1.0",
   "description": "F5 brand icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/hashicorp-flight/package.json
+++ b/packages/hashicorp-flight/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-hashicorp-flight",
+  "name": "@robinmordasiewicz/icons-hashicorp-flight",
   "version": "0.1.0",
   "description": "HashiCorp Flight icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/lucide/package.json
+++ b/packages/lucide/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-lucide",
+  "name": "@robinmordasiewicz/icons-lucide",
   "version": "0.1.0",
   "description": "Lucide icons with Astro component wrapper",
   "type": "module",

--- a/packages/mdi/package.json
+++ b/packages/mdi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-mdi",
+  "name": "@robinmordasiewicz/icons-mdi",
   "version": "0.1.0",
   "description": "Material Design Icons with Astro component wrapper",
   "type": "module",

--- a/packages/phosphor/package.json
+++ b/packages/phosphor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-phosphor",
+  "name": "@robinmordasiewicz/icons-phosphor",
   "version": "0.1.0",
   "description": "Phosphor icons with Astro component wrapper",
   "type": "module",

--- a/packages/tabler/package.json
+++ b/packages/tabler/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/icons-tabler",
+  "name": "@robinmordasiewicz/icons-tabler",
   "version": "0.1.0",
   "description": "Tabler icons with Astro component wrapper",
   "type": "module",


### PR DESCRIPTION
## Summary
- Rename all 7 icon package scopes from `@f5xc-salesdemos` to `@robinmordasiewicz`
- The `@f5xc-salesdemos` npm org doesn't exist, causing publish failures
- The `@robinmordasiewicz` npm org already exists

## Test plan
- [ ] npm publish workflow succeeds after merge
- [ ] `npm info @robinmordasiewicz/icons-f5-brand` shows published package

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)