### PR TITLE
fix: regenerate package-lock.json after scope rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,44 +9,12 @@
         "packages/*"
       ]
     },
-    "node_modules/@f5xc-salesdemos/icons-carbon": {
-      "resolved": "packages/carbon",
-      "link": true
-    },
-    "node_modules/@f5xc-salesdemos/icons-f5-brand": {
-      "resolved": "packages/f5-brand",
-      "link": true
-    },
-    "node_modules/@f5xc-salesdemos/icons-hashicorp-flight": {
-      "resolved": "packages/hashicorp-flight",
-      "link": true
-    },
-    "node_modules/@f5xc-salesdemos/icons-lucide": {
-      "resolved": "packages/lucide",
-      "link": true
-    },
-    "node_modules/@f5xc-salesdemos/icons-mdi": {
-      "resolved": "packages/mdi",
-      "link": true
-    },
-    "node_modules/@f5xc-salesdemos/icons-phosphor": {
-      "resolved": "packages/phosphor",
-      "link": true
-    },
-    "node_modules/@f5xc-salesdemos/icons-tabler": {
-      "resolved": "packages/tabler",
-      "link": true
-    },
     "node_modules/@hashicorp/flight-icons": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-4.2.0.tgz",
-      "integrity": "sha512-8ShfI0bxG74UmbWb4mrzS4jXAnU5GOJ1Tv2rvs/iRHxSpMl/l76E/QQpN0Fsad5CxbjoHOwNIkWZuLDSp9XELA==",
       "license": "MPL-2.0"
     },
     "node_modules/@iconify-json/carbon": {
       "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@iconify-json/carbon/-/carbon-1.2.18.tgz",
-      "integrity": "sha512-Grb13E6r/RqTEV4Sqd/BQR2FUt57U2WLuticJ5H8JbTdHLop1LmdePu3EJJA3Xi8DcWRbD6OnC133hKfOwlgtg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -54,8 +22,6 @@
     },
     "node_modules/@iconify-json/lucide": {
       "version": "1.2.90",
-      "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.90.tgz",
-      "integrity": "sha512-dPn1pRhfBa9KR+EVpdyM1Rvw3T36hCKYxd6TxK1ifffiNt0f5yXx8ZVhqnzPH4Vkz87yLMj5xFCXomNrnzd2kQ==",
       "license": "ISC",
       "dependencies": {
         "@iconify/types": "*"
@@ -63,8 +29,6 @@
     },
     "node_modules/@iconify-json/mdi": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.3.tgz",
-      "integrity": "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -72,8 +36,6 @@
     },
     "node_modules/@iconify-json/ph": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@iconify-json/ph/-/ph-1.2.2.tgz",
-      "integrity": "sha512-PgkEZNtqa8hBGjHXQa4pMwZa93hmfu8FUSjs/nv4oUU6yLsgv+gh9nu28Kqi8Fz9CCVu4hj1MZs9/60J57IzFw==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -81,8 +43,6 @@
     },
     "node_modules/@iconify-json/tabler": {
       "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/@iconify-json/tabler/-/tabler-1.2.26.tgz",
-      "integrity": "sha512-92G+ZD70AZgeJf07JfQzH+isnai6DwPcMBuF/qL1F+xAxdXCJzGd3w2RmsRvOmB+w1ImmWEEDms50QivQIjd6g==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -90,12 +50,38 @@
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
       "license": "MIT"
     },
+    "node_modules/@robinmordasiewicz/icons-carbon": {
+      "resolved": "packages/carbon",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-f5-brand": {
+      "resolved": "packages/f5-brand",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {
+      "resolved": "packages/hashicorp-flight",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-lucide": {
+      "resolved": "packages/lucide",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-mdi": {
+      "resolved": "packages/mdi",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-phosphor": {
+      "resolved": "packages/phosphor",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-tabler": {
+      "resolved": "packages/tabler",
+      "link": true
+    },
     "packages/carbon": {
-      "name": "@f5xc-salesdemos/icons-carbon",
+      "name": "@robinmordasiewicz/icons-carbon",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -103,12 +89,12 @@
       }
     },
     "packages/f5-brand": {
-      "name": "@f5xc-salesdemos/icons-f5-brand",
+      "name": "@robinmordasiewicz/icons-f5-brand",
       "version": "0.1.0",
       "license": "MIT"
     },
     "packages/hashicorp-flight": {
-      "name": "@f5xc-salesdemos/icons-hashicorp-flight",
+      "name": "@robinmordasiewicz/icons-hashicorp-flight",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -116,7 +102,7 @@
       }
     },
     "packages/lucide": {
-      "name": "@f5xc-salesdemos/icons-lucide",
+      "name": "@robinmordasiewicz/icons-lucide",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -124,7 +110,7 @@
       }
     },
     "packages/mdi": {
-      "name": "@f5xc-salesdemos/icons-mdi",
+      "name": "@robinmordasiewicz/icons-mdi",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -132,7 +118,7 @@
       }
     },
     "packages/phosphor": {
-      "name": "@f5xc-salesdemos/icons-phosphor",
+      "name": "@robinmordasiewicz/icons-phosphor",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -140,7 +126,7 @@
       }
     },
     "packages/tabler": {
-      "name": "@f5xc-salesdemos/icons-tabler",
+      "name": "@robinmordasiewicz/icons-tabler",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Regenerate package-lock.json to match the renamed @robinmordasiewicz scope packages

## Test plan
- [ ] `npm ci` succeeds in CI
- [ ] npm publish workflow succeeds after merge

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)