### PR TITLE
fix: add workflow_dispatch trigger to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'packages/**'
+      - 'package-lock.json'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to allow manual re-runs of npm publish
- Add `package-lock.json` to path filter so workflow triggers on lock file updates

## Test plan
- [ ] Workflow can be triggered manually after merge
- [ ] npm packages publish successfully

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)