### PR TITLE
fix: update packages table with correct npm scope and status

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -20,10 +20,10 @@ NPM icon packages providing uniform Iconify JSON icon sets with Astro components
 
 | Package | Icons | Status |
 |---------|-------|--------|
-| `@f5xc-salesdemos/icons-f5-brand` | 665 | Available |
-| `@f5xc-salesdemos/icons-lucide` | — | Planned |
-| `@f5xc-salesdemos/icons-mdi` | — | Planned |
-| `@f5xc-salesdemos/icons-carbon` | — | Planned |
-| `@f5xc-salesdemos/icons-phosphor` | — | Planned |
-| `@f5xc-salesdemos/icons-tabler` | — | Planned |
-| `@f5xc-salesdemos/icons-hashicorp-flight` | — | Planned |
+| `@robinmordasiewicz/icons-f5-brand` | 665 | Available |
+| `@robinmordasiewicz/icons-lucide` | 1,710 | Available |
+| `@robinmordasiewicz/icons-mdi` | 7,638 | Available |
+| `@robinmordasiewicz/icons-carbon` | 2,582 | Available |
+| `@robinmordasiewicz/icons-phosphor` | 9,161 | Available |
+| `@robinmordasiewicz/icons-tabler` | 6,034 | Available |
+| `@robinmordasiewicz/icons-hashicorp-flight` | 671 | Available |


### PR DESCRIPTION
## Summary

- Updated all 7 package names from `@f5xc-salesdemos` to `@robinmordasiewicz` scope
- Changed all "Planned" statuses to "Available"
- Added accurate icon counts from installed packages

## Related Issue

Closes #16

## Test plan

- [ ] Verify packages table renders correctly on GitHub Pages
- [ ] Confirm all 7 rows show `@robinmordasiewicz` scope
- [ ] Confirm all statuses show "Available"
- [ ] Confirm icon counts are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)