### PR TITLE
ci: dispatch docs-builder rebuild after npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,3 +40,16 @@ jobs:
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  dispatch:
+    name: Trigger docs-builder image rebuild
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch rebuild-image to docs-builder
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh api repos/f5xc-salesdemos/docs-builder/dispatches \
+            --method POST \
+            --field event_type=rebuild-image


### PR DESCRIPTION
## Summary

- Adds a `dispatch` job to the npm-publish workflow that sends a `repository_dispatch` event (`rebuild-image`) to `f5xc-salesdemos/docs-builder` after packages are successfully published
- Uses the existing `RELEASE_TOKEN` secret and mirrors the dispatch pattern already used in docs-builder's own workflow

Closes #18

## Test plan

- [ ] Trigger npm-publish workflow via `gh workflow run npm-publish.yml`
- [ ] Confirm the dispatch job runs successfully in workflow logs
- [ ] Confirm a new `build-image.yml` run appears in docs-builder triggered by `repository_dispatch`
- [ ] Confirm the Docker image rebuild completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)