### PR TITLE
fix: update package-lock.json for icons-f5xc workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,10 @@
       "resolved": "packages/f5-brand",
       "link": true
     },
+    "node_modules/@robinmordasiewicz/icons-f5xc": {
+      "resolved": "packages/f5xc",
+      "link": true
+    },
     "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {
       "resolved": "packages/hashicorp-flight",
       "link": true
@@ -90,6 +94,11 @@
     },
     "packages/f5-brand": {
       "name": "@robinmordasiewicz/icons-f5-brand",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "packages/f5xc": {
+      "name": "@robinmordasiewicz/icons-f5xc",
       "version": "0.1.0",
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary

- Run `npm install` to sync `package-lock.json` with the new `@robinmordasiewicz/icons-f5xc` workspace package added in #27

## Test plan

- [ ] `npm ci` succeeds in CI (npm publish workflow passes)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)