### PR TITLE
fix: correct relative paths for f5xc icon SVGs on production

### DIFF
--- a/docs/f5xc.mdx
+++ b/docs/f5xc.mdx
@@ -38,181 +38,181 @@ These multi-color icons use F5 brand colors (red, navy, light blue). They use th
 <div class="icon-grid">
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/account-protection.svg" alt="Account Protection" width="40" height="40" />
+      <img src="../f5xc-icons/account-protection.svg" alt="Account Protection" width="40" height="40" />
     </div>
     <div class="icon-card-label">account-protection</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/administration.svg" alt="Administration" width="40" height="40" />
+      <img src="../f5xc-icons/administration.svg" alt="Administration" width="40" height="40" />
     </div>
     <div class="icon-card-label">administration</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/ai_assistant_logo_24_x_24.svg" alt="AI Assistant" width="40" height="40" />
+      <img src="../f5xc-icons/ai_assistant_logo_24_x_24.svg" alt="AI Assistant" width="40" height="40" />
     </div>
     <div class="icon-card-label">ai_assistant_logo</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/application-traffic-insight.svg" alt="Application Traffic Insight" width="40" height="40" />
+      <img src="../f5xc-icons/application-traffic-insight.svg" alt="Application Traffic Insight" width="40" height="40" />
     </div>
     <div class="icon-card-label">application-traffic-insight</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/audit-logs-and-alerts.svg" alt="Audit Logs and Alerts" width="40" height="40" />
+      <img src="../f5xc-icons/audit-logs-and-alerts.svg" alt="Audit Logs and Alerts" width="40" height="40" />
     </div>
     <div class="icon-card-label">audit-logs-and-alerts</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/authentication-intelligence.svg" alt="Authentication Intelligence" width="40" height="40" />
+      <img src="../f5xc-icons/authentication-intelligence.svg" alt="Authentication Intelligence" width="40" height="40" />
     </div>
     <div class="icon-card-label">authentication-intelligence</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/big-ip-apm.svg" alt="BIG-IP APM" width="40" height="40" />
+      <img src="../f5xc-icons/big-ip-apm.svg" alt="BIG-IP APM" width="40" height="40" />
     </div>
     <div class="icon-card-label">big-ip-apm</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/big_ip_utilities_24_x_24.svg" alt="BIG-IP Utilities" width="40" height="40" />
+      <img src="../f5xc-icons/big_ip_utilities_24_x_24.svg" alt="BIG-IP Utilities" width="40" height="40" />
     </div>
     <div class="icon-card-label">big_ip_utilities</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/billing.svg" alt="Billing" width="40" height="40" />
+      <img src="../f5xc-icons/billing.svg" alt="Billing" width="40" height="40" />
     </div>
     <div class="icon-card-label">billing</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/bot-defense.svg" alt="Bot Defense" width="40" height="40" />
+      <img src="../f5xc-icons/bot-defense.svg" alt="Bot Defense" width="40" height="40" />
     </div>
     <div class="icon-card-label">bot-defense</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/client-side-defense.svg" alt="Client-Side Defense" width="40" height="40" />
+      <img src="../f5xc-icons/client-side-defense.svg" alt="Client-Side Defense" width="40" height="40" />
     </div>
     <div class="icon-card-label">client-side-defense</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/content-delivery-network.svg" alt="Content Delivery Network" width="40" height="40" />
+      <img src="../f5xc-icons/content-delivery-network.svg" alt="Content Delivery Network" width="40" height="40" />
     </div>
     <div class="icon-card-label">content-delivery-network</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/data-intelligence-24x24.svg" alt="Data Intelligence" width="40" height="40" />
+      <img src="../f5xc-icons/data-intelligence-24x24.svg" alt="Data Intelligence" width="40" height="40" />
     </div>
     <div class="icon-card-label">data-intelligence</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/ddos-and-transit-services.svg" alt="DDoS and Transit Services" width="40" height="40" />
+      <img src="../f5xc-icons/ddos-and-transit-services.svg" alt="DDoS and Transit Services" width="40" height="40" />
     </div>
     <div class="icon-card-label">ddos-and-transit-services</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/delegated-access.svg" alt="Delegated Access" width="40" height="40" />
+      <img src="../f5xc-icons/delegated-access.svg" alt="Delegated Access" width="40" height="40" />
     </div>
     <div class="icon-card-label">delegated-access</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/distributed-apps.svg" alt="Distributed Apps" width="40" height="40" />
+      <img src="../f5xc-icons/distributed-apps.svg" alt="Distributed Apps" width="40" height="40" />
     </div>
     <div class="icon-card-label">distributed-apps</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/dns-management.svg" alt="DNS Management" width="40" height="40" />
+      <img src="../f5xc-icons/dns-management.svg" alt="DNS Management" width="40" height="40" />
     </div>
     <div class="icon-card-label">dns-management</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/doc.svg" alt="Documentation" width="40" height="40" />
+      <img src="../f5xc-icons/doc.svg" alt="Documentation" width="40" height="40" />
     </div>
     <div class="icon-card-label">doc</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/mobile_app_shield_24_x_24.svg" alt="Mobile App Shield" width="40" height="40" />
+      <img src="../f5xc-icons/mobile_app_shield_24_x_24.svg" alt="Mobile App Shield" width="40" height="40" />
     </div>
     <div class="icon-card-label">mobile_app_shield</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/multi-cloud-app-connect.svg" alt="Multi-Cloud App Connect" width="40" height="40" />
+      <img src="../f5xc-icons/multi-cloud-app-connect.svg" alt="Multi-Cloud App Connect" width="40" height="40" />
     </div>
     <div class="icon-card-label">multi-cloud-app-connect</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/multi-cloud-network-connect.svg" alt="Multi-Cloud Network Connect" width="40" height="40" />
+      <img src="../f5xc-icons/multi-cloud-network-connect.svg" alt="Multi-Cloud Network Connect" width="40" height="40" />
     </div>
     <div class="icon-card-label">multi-cloud-network-connect</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/nginx-one-24x24.svg" alt="NGINX One" width="40" height="40" />
+      <img src="../f5xc-icons/nginx-one-24x24.svg" alt="NGINX One" width="40" height="40" />
     </div>
     <div class="icon-card-label">nginx-one</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/observability.svg" alt="Observability" width="40" height="40" />
+      <img src="../f5xc-icons/observability.svg" alt="Observability" width="40" height="40" />
     </div>
     <div class="icon-card-label">observability</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/platform.svg" alt="Platform" width="40" height="40" />
+      <img src="../f5xc-icons/platform.svg" alt="Platform" width="40" height="40" />
     </div>
     <div class="icon-card-label">platform</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/shared-configuration.svg" alt="Shared Configuration" width="40" height="40" />
+      <img src="../f5xc-icons/shared-configuration.svg" alt="Shared Configuration" width="40" height="40" />
     </div>
     <div class="icon-card-label">shared-configuration</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/support_24_x_24.svg" alt="Support" width="40" height="40" />
+      <img src="../f5xc-icons/support_24_x_24.svg" alt="Support" width="40" height="40" />
     </div>
     <div class="icon-card-label">support</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/user-support.svg" alt="User Support" width="40" height="40" />
+      <img src="../f5xc-icons/user-support.svg" alt="User Support" width="40" height="40" />
     </div>
     <div class="icon-card-label">user-support</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/voltshare.svg" alt="VoltShare" width="40" height="40" />
+      <img src="../f5xc-icons/voltshare.svg" alt="VoltShare" width="40" height="40" />
     </div>
     <div class="icon-card-label">voltshare</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/web-app-and-api-protection.svg" alt="Web App &amp; API Protection" width="40" height="40" />
+      <img src="../f5xc-icons/web-app-and-api-protection.svg" alt="Web App &amp; API Protection" width="40" height="40" />
     </div>
     <div class="icon-card-label">web-app-and-api-protection</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
-      <img src="../../f5xc-icons/web-app-scanning-24x24.svg" alt="Web App Scanning" width="40" height="40" />
+      <img src="../f5xc-icons/web-app-scanning-24x24.svg" alt="Web App Scanning" width="40" height="40" />
     </div>
     <div class="icon-card-label">web-app-scanning</div>
   </div>


### PR DESCRIPTION
## Summary
- Fixed all 30 `<img src>` paths in `docs/f5xc.mdx` from `../../f5xc-icons/` to `../f5xc-icons/`
- The `../../` pattern escaped above the `/docs-icons/` base path on GitHub Pages, causing 404s for every icon

## Test plan
- [ ] CI passes
- [ ] After deploy, verify icons load at `https://f5xc-salesdemos.github.io/docs-icons/f5xc/`
- [ ] Confirm `../f5xc-icons/` resolves to `/docs-icons/f5xc-icons/` on production

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)