### PR TITLE
fix: correct renamed Lucide icon names in docs

### DIFF
--- a/docs/brand.mdx
+++ b/docs/brand.mdx
@@ -18,7 +18,7 @@ import Icon from '@robinmordasiewicz/icons-f5-brand/Icon.astro';
 ---
 
 <Icon name="ai-admin" size="3rem" />
-<Icon name="cloud-security" size="2rem" label="Cloud Security" />
+<Icon name="cloud-shield-checkmark" size="2rem" label="Cloud Security" />
 ```
 
 Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.

--- a/docs/lucide.mdx
+++ b/docs/lucide.mdx
@@ -36,7 +36,7 @@ Icons render as inline SVGs using `currentColor` — they automatically adapt to
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chevron-left" size="1.5rem" /></div><div class="icon-card-label">chevron-left</div></div>
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chevron-right" size="1.5rem" /></div><div class="icon-card-label">chevron-right</div></div>
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="external-link" size="1.5rem" /></div><div class="icon-card-label">external-link</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="home" size="1.5rem" /></div><div class="icon-card-label">home</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="house" size="1.5rem" /></div><div class="icon-card-label">house</div></div>
 </div>
 
 ## Actions
@@ -84,7 +84,7 @@ Icons render as inline SVGs using `currentColor` — they automatically adapt to
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="unlock" size="1.5rem" /></div><div class="icon-card-label">unlock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lock-open" size="1.5rem" /></div><div class="icon-card-label">lock-open</div></div>
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="key-round" size="1.5rem" /></div><div class="icon-card-label">key-round</div></div>
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="eye" size="1.5rem" /></div><div class="icon-card-label">eye</div></div>
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="triangle-alert" size="1.5rem" /></div><div class="icon-card-label">triangle-alert</div></div>


### PR DESCRIPTION
## Summary
- Fix `home` → `house` in lucide.mdx (Lucide renamed this icon)
- Fix `unlock` → `lock-open` in lucide.mdx (Lucide renamed this icon)
- Fix `cloud-security` → `cloud-shield-checkmark` in brand.mdx code example

## Test plan
- [ ] CI build passes with corrected icon names
- [ ] All icon grids render correctly on docs site

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)