### PR TITLE
feat: add retry and verification logic to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -21,23 +22,112 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          retry_with_backoff() {
+            local max_attempts=$1; shift
+            local delay=$1; shift
+            local attempt=1
+            while [ $attempt -le $max_attempts ]; do
+              echo "Attempt $attempt/$max_attempts: $*"
+              if "$@"; then
+                return 0
+              fi
+              if [ $attempt -eq $max_attempts ]; then
+                echo "All $max_attempts attempts failed"
+                return 1
+              fi
+              echo "Waiting ${delay}s before retry..."
+              sleep $delay
+              delay=$((delay * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+          retry_with_backoff 3 5 npm ci
 
       - run: npm run build
 
-      - name: Publish packages
+      - name: Publish and verify packages
         run: |
-          for pkg in packages/*/; do
+          retry_with_backoff() {
+            local max_attempts=$1; shift
+            local delay=$1; shift
+            local attempt=1
+            while [ $attempt -le $max_attempts ]; do
+              echo "Attempt $attempt/$max_attempts: $*"
+              if "$@"; then
+                return 0
+              fi
+              if [ $attempt -eq $max_attempts ]; then
+                echo "All $max_attempts attempts failed"
+                return 1
+              fi
+              echo "Waiting ${delay}s before retry..."
+              sleep $delay
+              delay=$((delay * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          publish_package() {
+            local pkg=$1
+            local name version published
             name=$(node -p "require('./${pkg}package.json').name")
             version=$(node -p "require('./${pkg}package.json').version")
             published=$(npm view "$name@$version" version 2>/dev/null || echo "")
             if [ "$published" = "$version" ]; then
               echo "Skipping $name@$version (already published)"
-            else
-              echo "Publishing $name@$version"
-              npm publish --workspace "$pkg"
+              return 0
             fi
+            echo "Publishing $name@$version"
+            retry_with_backoff 5 10 npm publish --workspace "$pkg"
+            echo "$name@$version" >> "$NEWLY_PUBLISHED"
+          }
+
+          verify_published() {
+            if [ ! -s "$NEWLY_PUBLISHED" ]; then
+              echo "No new packages to verify"
+              return 0
+            fi
+            local failures=0
+            while IFS= read -r entry; do
+              local name="${entry%@*}"
+              local version="${entry##*@}"
+              echo "Verifying $name@$version is available on registry..."
+              local attempt=1 max_attempts=10 delay=5
+              local found=false
+              while [ $attempt -le $max_attempts ]; do
+                if [ "$(npm view "$name@$version" version 2>/dev/null || echo "")" = "$version" ]; then
+                  echo "Confirmed $name@$version is available"
+                  found=true
+                  break
+                fi
+                echo "Not yet available (attempt $attempt/$max_attempts), waiting ${delay}s..."
+                sleep $delay
+                delay=$((delay * 2))
+                if [ $delay -gt 60 ]; then delay=60; fi
+                attempt=$((attempt + 1))
+              done
+              if [ "$found" = false ]; then
+                echo "ERROR: $name@$version not available after $max_attempts attempts"
+                failures=$((failures + 1))
+              fi
+            done < "$NEWLY_PUBLISHED"
+            if [ $failures -gt 0 ]; then
+              echo "ERROR: $failures package(s) failed verification"
+              return 1
+            fi
+            echo "All packages verified available"
+          }
+
+          NEWLY_PUBLISHED=$(mktemp)
+          export NEWLY_PUBLISHED
+
+          for pkg in packages/*/; do
+            publish_package "$pkg"
           done
+
+          verify_published
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 15` to publish job as safety net against runaway retries
- Add retry with exponential backoff to `npm ci` (3 attempts, 5s initial delay)
- Wrap `npm publish` with retry (5 attempts, 10s initial, exponential backoff)
- Add post-publish registry verification (polls 10x, 5s initial, 60s cap) before dispatching to `docs-builder`
- Dispatch only fires after all newly published packages are confirmed available on the registry

Closes #42

## Test plan
- [ ] Trigger via `workflow_dispatch` and monitor Actions log
- [ ] Confirm retry messages appear for `npm ci` step
- [ ] Confirm publish step shows skip/publish decisions per package
- [ ] Confirm verification step polls and confirms availability
- [ ] Confirm dispatch fires only after verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)