### PR TITLE
fix: bump f5xc package version to publish dark mode changes

### DIFF
--- a/packages/f5xc/package.json
+++ b/packages/f5xc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robinmordasiewicz/icons-f5xc",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "F5 Distributed Cloud (XC) service icons in Iconify JSON format with Astro component",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bump `@robinmordasiewicz/icons-f5xc` from `0.2.0` to `0.3.0` to trigger npm publish
- The dark mode CSS variable changes from #44 were skipped because `0.2.0` was already published

## Test plan

- [ ] npm publish workflow publishes `@robinmordasiewicz/icons-f5xc@0.3.0` (not skipped)
- [ ] Published icons.json contains `var(--color-N600, ...)` instead of hardcoded hex
- [ ] docs-builder dispatch triggered to rebuild Docker image
- [ ] Live docs site shows theme-adaptive icons after rebuild

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)