### PR TITLE
docs: simplify page titles and restructure index

### DIFF
--- a/docs/f5xc.mdx
+++ b/docs/f5xc.mdx
@@ -1,8 +1,8 @@
 ---
-title: F5 XC Service Icons
+title: F5 XC
 description: Visual reference for all 30 F5 Distributed Cloud (XC) service icons from @robinmordasiewicz/icons-f5xc.
 sidebar:
-  label: F5 XC Services
+  label: F5 XC
   order: 7
 ---
 

--- a/docs/iconify-packs.mdx
+++ b/docs/iconify-packs.mdx
@@ -1,8 +1,8 @@
 ---
-title: Iconify Packs
+title: Iconify
 description: Curated reference for Material Design, Carbon, Phosphor, and Tabler icon packs available via Icon components.
 sidebar:
-  label: Iconify Packs
+  label: Iconify
   order: 5
 ---
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,31 +1,7 @@
 ---
-title: Docs Icons
+title: Icons
 description: NPM icon packages and plugins for the F5 XC documentation build system
+hero:
+  title: Icons
+  tagline: NPM icon packages providing uniform Iconify JSON icon sets with Astro `Icon` components for the F5 XC documentation build system. Every pack uses the same pattern: import the pack's `Icon.astro` component and reference icons by name.
 ---
-
-# Docs Icons
-
-NPM icon packages providing uniform Iconify JSON icon sets with Astro `Icon` components for the F5 XC documentation build system. Every pack uses the same pattern: import the pack's `Icon.astro` component and reference icons by name.
-
-## Icon Reference
-
-- [Overview](/icons/) — Available icon packs, unified usage pattern, and selection guide
-- [Starlight Built-in](/starlight/) — 200+ built-in icons via the `&lt;Icon&gt;` component
-- [F5 Brand](/brand/) — 665 SVG icons for networking, security, cloud, and AI
-- [Lucide](/lucide/) — 1,600+ modern stroke icons
-- [Iconify Packs](/iconify-packs/) — Material Design, Carbon, Phosphor, and Tabler
-- [F5 XC Services](/f5xc/) — 30 F5 Distributed Cloud service icons
-- [HashiCorp Flight](/hashicorp-flight/) — 671 cloud and infrastructure vendor icons
-
-## Packages
-
-| Package | Icons | Status |
-|---------|-------|--------|
-| `@robinmordasiewicz/icons-f5-brand` | 665 | Available |
-| `@robinmordasiewicz/icons-lucide` | 1,710 | Available |
-| `@robinmordasiewicz/icons-mdi` | 7,638 | Available |
-| `@robinmordasiewicz/icons-carbon` | 2,582 | Available |
-| `@robinmordasiewicz/icons-phosphor` | 9,161 | Available |
-| `@robinmordasiewicz/icons-tabler` | 6,034 | Available |
-| `@robinmordasiewicz/icons-f5xc` | 30 | Available |
-| `@robinmordasiewicz/icons-hashicorp-flight` | 671 | Available |


### PR DESCRIPTION
Closes #58

Simplify page titles for cleaner sidebar navigation:
- F5 XC Service Icons → F5 XC
- Iconify Packs → Iconify

Restructure index.mdx to use Starlight hero section with tagline instead of traditional markdown content structure. Maintains key information while providing cleaner visual presentation.