### PR TITLE
fix: resolve YAML indentation in index.mdx frontmatter

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,5 +3,9 @@ title: Icons
 description: NPM icon packages and plugins for the F5 XC documentation build system
 hero:
   title: Icons
-  tagline: NPM icon packages providing uniform Iconify JSON icon sets with Astro `Icon` components for the F5 XC documentation build system. Every pack uses the same pattern: import the pack's `Icon.astro` component and reference icons by name.
+  tagline: >-
+    NPM icon packages providing uniform Iconify JSON icon sets with Astro
+    `Icon` components for the F5 XC documentation build system. Every pack
+    uses the same pattern: import the pack's `Icon.astro` component and
+    reference icons by name.
 ---


### PR DESCRIPTION
Closes #60

Use YAML folded scalar (>-) for the long tagline text to properly handle multi-line formatting without triggering YAML indentation parsing errors.

This resolves the GitHub Pages build failure that was triggered by PR #59 during the post-merge workflow.