### PR TITLE
feat: add instagram-color icon to hashicorp-flight pack

### DIFF
--- a/docs/hashicorp-flight.mdx
+++ b/docs/hashicorp-flight.mdx
@@ -1,6 +1,6 @@
 ---
 title: HashiCorp Flight Icons
-description: Visual reference for all 671 HashiCorp Flight icons from @robinmordasiewicz/icons-hashicorp-flight.
+description: Visual reference for all 672 HashiCorp Flight icons from @robinmordasiewicz/icons-hashicorp-flight.
 sidebar:
   label: HashiCorp Flight
   order: 6
@@ -27,7 +27,7 @@ Icons render as inline SVGs using `currentColor` — monochrome icons automatica
 Monochrome icons use `currentColor` and adapt automatically. Color variants (icons ending in `-color`) preserve their original colors via the `no-invert` class.
 :::
 
-## Services (243)
+## Services (244)
 
 <div class="icon-grid">
   <div class="icon-card">
@@ -725,6 +725,12 @@ Monochrome icons use `currentColor` and adapt automatically. Color variants (ico
       <Icon name="infracost-color" size="1.5rem" />
     </div>
     <div class="icon-card-label">infracost-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">
+      <Icon name="instagram-color" size="1.5rem" />
+    </div>
+    <div class="icon-card-label">instagram-color</div>
   </div>
   <div class="icon-card">
     <div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;">

--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -26,7 +26,7 @@ The documentation theme provides access to thousands of icons from multiple pack
 | Phosphor | ~1,200 | `<Icon name="globe" />` | [Iconify Packs](/iconify-packs/) |
 | Tabler | ~4,500 | `<Icon name="shield" />` | [Iconify Packs](/iconify-packs/) |
 | F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| HashiCorp Flight | 671 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
 
 ## Rendering Method
 


### PR DESCRIPTION
## Summary

Add instagram-color icon to the HashiCorp Flight icon pack.

## Changes

- Add instagram-color icon to Services section icon grid in hashicorp-flight.mdx
- Update HashiCorp Flight icon count from 671 to 672
- Update Services section count from 243 to 244
- Update icons reference documentation (icons.mdx) with new total count

Closes #62