### PR TITLE
fix: add sidebar order to index.mdx and reorder all docs pages

### DIFF
--- a/docs/brand.mdx
+++ b/docs/brand.mdx
@@ -3,7 +3,7 @@ title: F5 Brand Icons
 description: Icon library — 665 SVG icons organized by category for diagrams, presentations, and documentation.
 sidebar:
   label: F5 Brand
-  order: 3
+  order: 4
 ---
 
 import Icon from '@robinmordasiewicz/icons-f5-brand/Icon.astro';

--- a/docs/f5xc.mdx
+++ b/docs/f5xc.mdx
@@ -3,7 +3,7 @@ title: F5 XC
 description: Visual reference for all 30 F5 Distributed Cloud (XC) service icons from @robinmordasiewicz/icons-f5xc.
 sidebar:
   label: F5 XC
-  order: 7
+  order: 8
 ---
 
 import Icon from '@robinmordasiewicz/icons-f5xc/Icon.astro';

--- a/docs/hashicorp-flight.mdx
+++ b/docs/hashicorp-flight.mdx
@@ -3,7 +3,7 @@ title: HashiCorp Flight Icons
 description: Visual reference for all 672 HashiCorp Flight icons from @robinmordasiewicz/icons-hashicorp-flight.
 sidebar:
   label: HashiCorp Flight
-  order: 6
+  order: 7
 ---
 
 import Icon from '@robinmordasiewicz/icons-hashicorp-flight/Icon.astro';

--- a/docs/iconify-packs.mdx
+++ b/docs/iconify-packs.mdx
@@ -3,7 +3,7 @@ title: Iconify
 description: Curated reference for Material Design, Carbon, Phosphor, and Tabler icon packs available via Icon components.
 sidebar:
   label: Iconify
-  order: 5
+  order: 6
 ---
 
 import MdiIcon from '@robinmordasiewicz/icons-mdi/Icon.astro';

--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -3,7 +3,7 @@ title: Icon Reference
 description: Overview of all icon packs available in the documentation theme — usage, dark mode behavior, and selection guide.
 sidebar:
   label: Overview
-  order: 1
+  order: 2
 ---
 
 import { Icon } from '@astrojs/starlight/components';

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Icons
 description: NPM icon packages and plugins for the F5 XC documentation build system
+sidebar:
+  order: 1
 hero:
   title: Icons
   tagline: >-

--- a/docs/lucide.mdx
+++ b/docs/lucide.mdx
@@ -3,7 +3,7 @@ title: Lucide Icons
 description: Curated reference for Lucide icons — 1,600+ modern stroke icons available via the Icon component.
 sidebar:
   label: Lucide
-  order: 4
+  order: 5
 ---
 
 import Icon from '@robinmordasiewicz/icons-lucide/Icon.astro';

--- a/docs/starlight.mdx
+++ b/docs/starlight.mdx
@@ -3,7 +3,7 @@ title: Starlight Built-in Icons
 description: Complete reference for all 200+ built-in Starlight icons available via the Icon component.
 sidebar:
   label: Starlight Built-in
-  order: 2
+  order: 3
 ---
 
 import { Icon } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary
- Added `sidebar.order: 1` to `docs/index.mdx` which was missing a sidebar order value
- Incremented `sidebar.order` by 1 in all other docs pages to maintain correct navigation sequence

## Test plan
- [ ] Verify sidebar order in dev server: Icons → Overview → Starlight Built-in → F5 Brand → Lucide → Iconify → HashiCorp Flight → F5 XC
- [ ] Verify previous/next navigation links follow the same sequence

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)