### PR TITLE
fix: hide index.mdx from sidebar navigation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,6 +2,7 @@
 title: Icons
 description: NPM icon packages and plugins for the F5 XC documentation build system
 sidebar:
+  hidden: true
   order: 1
 hero:
   title: Icons


### PR DESCRIPTION
## Summary
- Added `hidden: true` to the sidebar frontmatter in `docs/index.mdx` so the landing page does not appear in the sidebar navigation

## Test plan
- [ ] Verify the landing page no longer appears as a sidebar entry
- [ ] Verify the landing page is still accessible via the site title link

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)