### PR TITLE
feat: add simple-icons brand icon package

### DIFF
--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -26,6 +26,7 @@ The documentation theme provides access to thousands of icons from multiple pack
 | Phosphor | ~1,200 | `<Icon name="globe" />` | [Iconify Packs](/iconify-packs/) |
 | Tabler | ~4,500 | `<Icon name="shield" />` | [Iconify Packs](/iconify-packs/) |
 | F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
 | HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
 
 ## Rendering Method
@@ -87,4 +88,5 @@ F5 XC service icons use CSS custom properties that automatically adapt to light 
 | Flexible weight options | Phosphor | Thin/light/regular/bold/fill/duotone |
 | Crisp line icons | Tabler | 4,500+ with consistent stroke |
 | F5 XC service diagrams | F5 XC Services | 30 Distributed Cloud service icons |
+| Brand/company logos | Simple Icons | 3,200+ brand icons for vendors and services |
 | Cloud/infra vendor logos | HashiCorp Flight | AWS, GCP, Azure, K8s vendor icons |

--- a/docs/simple-icons.mdx
+++ b/docs/simple-icons.mdx
@@ -1,0 +1,85 @@
+---
+title: Simple Icons
+description: 3,200+ brand icons for popular companies, services, and technologies from the Simple Icons project.
+sidebar:
+  label: Simple Icons
+  order: 7
+---
+
+import SimpleIcon from '@robinmordasiewicz/icons-simple-icons/Icon.astro';
+
+Simple Icons provides 3,200+ free SVG icons for popular brands including network vendors, cloud providers, telecom companies, and technology services. All icons use a standard 24x24 viewBox.
+
+## Usage
+
+```astro
+---
+import SimpleIcon from '@robinmordasiewicz/icons-simple-icons/Icon.astro';
+---
+
+<SimpleIcon name="cloudflare" />
+<SimpleIcon name="akamai" size="2rem" />
+```
+
+## Network and Security Vendors
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="akamai" size="1.5rem" /></div><div class="icon-card-label">akamai</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="cloudflare" size="1.5rem" /></div><div class="icon-card-label">cloudflare</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="fastly" size="1.5rem" /></div><div class="icon-card-label">fastly</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="paloaltonetworks" size="1.5rem" /></div><div class="icon-card-label">paloaltonetworks</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="fortinet" size="1.5rem" /></div><div class="icon-card-label">fortinet</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="junipernetworks" size="1.5rem" /></div><div class="icon-card-label">junipernetworks</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="cisco" size="1.5rem" /></div><div class="icon-card-label">cisco</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="wireshark" size="1.5rem" /></div><div class="icon-card-label">wireshark</div></div>
+</div>
+
+## Telecom and Service Providers
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="verizon" size="1.5rem" /></div><div class="icon-card-label">verizon</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="vodafone" size="1.5rem" /></div><div class="icon-card-label">vodafone</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="deutschetelekom" size="1.5rem" /></div><div class="icon-card-label">deutschetelekom</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="orange" size="1.5rem" /></div><div class="icon-card-label">orange</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="telefonica" size="1.5rem" /></div><div class="icon-card-label">telefonica</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="telenor" size="1.5rem" /></div><div class="icon-card-label">telenor</div></div>
+</div>
+
+## Cloud Providers
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="amazonwebservices" size="1.5rem" /></div><div class="icon-card-label">amazonwebservices</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="microsoftazure" size="1.5rem" /></div><div class="icon-card-label">microsoftazure</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="googlecloud" size="1.5rem" /></div><div class="icon-card-label">googlecloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="oracle" size="1.5rem" /></div><div class="icon-card-label">oracle</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="digitalocean" size="1.5rem" /></div><div class="icon-card-label">digitalocean</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="vultr" size="1.5rem" /></div><div class="icon-card-label">vultr</div></div>
+</div>
+
+## DevOps and Infrastructure
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="docker" size="1.5rem" /></div><div class="icon-card-label">docker</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="kubernetes" size="1.5rem" /></div><div class="icon-card-label">kubernetes</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="terraform" size="1.5rem" /></div><div class="icon-card-label">terraform</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="ansible" size="1.5rem" /></div><div class="icon-card-label">ansible</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="github" size="1.5rem" /></div><div class="icon-card-label">github</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="gitlab" size="1.5rem" /></div><div class="icon-card-label">gitlab</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="jenkins" size="1.5rem" /></div><div class="icon-card-label">jenkins</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="nginx" size="1.5rem" /></div><div class="icon-card-label">nginx</div></div>
+</div>
+
+## Technology and Software
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="python" size="1.5rem" /></div><div class="icon-card-label">python</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="go" size="1.5rem" /></div><div class="icon-card-label">go</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="rust" size="1.5rem" /></div><div class="icon-card-label">rust</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="linux" size="1.5rem" /></div><div class="icon-card-label">linux</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="grafana" size="1.5rem" /></div><div class="icon-card-label">grafana</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="prometheus" size="1.5rem" /></div><div class="icon-card-label">prometheus</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="elasticsearch" size="1.5rem" /></div><div class="icon-card-label">elasticsearch</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><SimpleIcon name="redis" size="1.5rem" /></div><div class="icon-card-label">redis</div></div>
+</div>
+
+Browse all 3,200+ icons: [Simple Icons website](https://simpleicons.org/) | [Iconify explorer](https://icon-sets.iconify.design/simple-icons/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,15 @@
         "@iconify/types": "*"
       }
     },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.71",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.71.tgz",
+      "integrity": "sha512-rNoDFbq1fAYiEexBvrw613/xiUOPEu5MKVV/X8lI64AgdTzLQUUemr9f9fplxUMPoxCBP2rWzlhOEeTHk/Sf0Q==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
     "node_modules/@iconify-json/tabler": {
       "version": "1.2.26",
       "license": "MIT",
@@ -80,6 +89,10 @@
     },
     "node_modules/@robinmordasiewicz/icons-phosphor": {
       "resolved": "packages/phosphor",
+      "link": true
+    },
+    "node_modules/@robinmordasiewicz/icons-simple-icons": {
+      "resolved": "packages/simple-icons",
       "link": true
     },
     "node_modules/@robinmordasiewicz/icons-tabler": {
@@ -134,6 +147,14 @@
       "license": "MIT",
       "dependencies": {
         "@iconify-json/ph": "^1.2.0"
+      }
+    },
+    "packages/simple-icons": {
+      "name": "@robinmordasiewicz/icons-simple-icons",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify-json/simple-icons": "^1"
       }
     },
     "packages/tabler": {

--- a/packages/simple-icons/BaseIcon.astro
+++ b/packages/simple-icons/BaseIcon.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  name: string;
+  icons: Record<string, { body: string; width?: number; height?: number }>;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const {
+  name,
+  icons,
+  defaultWidth = 24,
+  defaultHeight = 24,
+  size = '1.5em',
+  label,
+  class: className,
+} = Astro.props;
+
+const icon = icons[name];
+if (!icon) {
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
+}
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={`0 0 ${icon.width || defaultWidth} ${icon.height || defaultHeight}`}
+  width={size}
+  height={size}
+  fill="currentColor"
+  class:list={[className]}
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={icon.body}
+/>

--- a/packages/simple-icons/Icon.astro
+++ b/packages/simple-icons/Icon.astro
@@ -1,0 +1,15 @@
+---
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/simple-icons/icons.json';
+
+interface Props {
+  name: string;
+  size?: string;
+  label?: string;
+  class?: string;
+}
+
+const props = Astro.props;
+---
+
+<BaseIcon icons={iconData.icons} defaultWidth={24} defaultHeight={24} {...props} />

--- a/packages/simple-icons/package.json
+++ b/packages/simple-icons/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@robinmordasiewicz/icons-simple-icons",
+  "version": "0.1.0",
+  "description": "Simple Icons brand icons in Iconify JSON format with Astro component",
+  "type": "module",
+  "exports": {
+    ".": "./icons.json",
+    "./Icon.astro": "./Icon.astro",
+    "./icons.json": "./icons.json"
+  },
+  "files": [
+    "Icon.astro",
+    "BaseIcon.astro",
+    "icons.json"
+  ],
+  "dependencies": {
+    "@iconify-json/simple-icons": "^1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": ["simple-icons", "brands", "icons", "iconify", "astro"],
+  "license": "MIT"
+}

--- a/packages/simple-icons/scripts/build.mjs
+++ b/packages/simple-icons/scripts/build.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/**
+ * Copies the Iconify JSON file from @iconify-json/simple-icons into this package
+ * so it can be exported alongside Icon.astro.
+ */
+
+import { copyFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const source = require.resolve('@iconify-json/simple-icons/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
+
+copyFileSync(source, dest);
+console.log(`Copied simple-icons icons.json \u2192 ${dest}`);

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -9,7 +9,7 @@
  * - hashicorp-flight: from @hashicorp/flight-icons
  *
  * Wrapper packages (copy icons.json from @iconify-json deps):
- * - lucide, carbon, mdi, phosphor, tabler
+ * - lucide, carbon, mdi, phosphor, tabler, simple-icons
  */
 
 import { execSync } from 'node:child_process';
@@ -28,6 +28,7 @@ const builds = [
   { name: 'mdi', script: 'packages/mdi/scripts/build.mjs' },
   { name: 'phosphor', script: 'packages/phosphor/scripts/build.mjs' },
   { name: 'tabler', script: 'packages/tabler/scripts/build.mjs' },
+  { name: 'simple-icons', script: 'packages/simple-icons/scripts/build.mjs' },
 ];
 
 let failed = false;


### PR DESCRIPTION
## Summary
- Add new `packages/simple-icons/` wrapper package wrapping `@iconify-json/simple-icons`
- Provides 3,670 brand icons including network vendors (Akamai, Cloudflare, Palo Alto Networks, Fortinet, Juniper), telecom providers (Verizon, Vodafone, Deutsche Telekom, Orange), cloud providers (AWS, Azure, GCP), and DevOps tools
- Add documentation page at `docs/simple-icons.mdx` with categorized icon grids
- Update overview page to include Simple Icons in pack table and selection guide

## Test plan
- [x] `npm install` succeeds with new workspace package
- [x] `npm run build` produces `packages/simple-icons/icons.json` (3,670 icons)
- [x] Key vendor icons verified present: akamai, cloudflare, verizon, vodafone, paloaltonetworks, fortinet, junipernetworks
- [ ] CI checks pass
- [ ] Docs page renders correctly after merge

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)