### PR TITLE
feat!: migrate icon packages to @f5xc-salesdemos npm scope

### DIFF
--- a/docs/brand.mdx
+++ b/docs/brand.mdx
@@ -6,15 +6,15 @@ sidebar:
   order: 4
 ---
 
-import Icon from '@robinmordasiewicz/icons-f5-brand/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-f5-brand/Icon.astro';
 
-The F5 brand icon library provides 50x50 SVG line-art icons covering networking, security, cloud, AI, and other technology domains. Use the `Icon` component from `@robinmordasiewicz/icons-f5-brand` to render any icon by name.
+The F5 brand icon library provides 50x50 SVG line-art icons covering networking, security, cloud, AI, and other technology domains. Use the `Icon` component from `@f5xc-salesdemos/icons-f5-brand` to render any icon by name.
 
 ## Usage
 
 ```astro
 ---
-import Icon from '@robinmordasiewicz/icons-f5-brand/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-f5-brand/Icon.astro';
 ---
 
 <Icon name="ai-admin" size="3rem" />

--- a/docs/cloud-icons.mdx
+++ b/docs/cloud-icons.mdx
@@ -6,9 +6,9 @@ sidebar:
   order: 8
 ---
 
-import AwsIcon from '@robinmordasiewicz/icons-aws/Icon.astro';
-import AzureIcon from '@robinmordasiewicz/icons-azure/Icon.astro';
-import GcpIcon from '@robinmordasiewicz/icons-gcp/Icon.astro';
+import AwsIcon from '@f5xc-salesdemos/icons-aws/Icon.astro';
+import AzureIcon from '@f5xc-salesdemos/icons-azure/Icon.astro';
+import GcpIcon from '@f5xc-salesdemos/icons-gcp/Icon.astro';
 
 Three icon packs provide color service icons for documenting cloud infrastructure. Unlike monochrome icon packs, these preserve original vendor colors for architecture diagrams.
 
@@ -16,9 +16,9 @@ Three icon packs provide color service icons for documenting cloud infrastructur
 
 ```astro
 ---
-import AwsIcon from '@robinmordasiewicz/icons-aws/Icon.astro';
-import AzureIcon from '@robinmordasiewicz/icons-azure/Icon.astro';
-import GcpIcon from '@robinmordasiewicz/icons-gcp/Icon.astro';
+import AwsIcon from '@f5xc-salesdemos/icons-aws/Icon.astro';
+import AzureIcon from '@f5xc-salesdemos/icons-azure/Icon.astro';
+import GcpIcon from '@f5xc-salesdemos/icons-gcp/Icon.astro';
 ---
 
 <AwsIcon name="lambda" />

--- a/docs/f5xc.mdx
+++ b/docs/f5xc.mdx
@@ -1,20 +1,20 @@
 ---
 title: F5 XC
-description: Visual reference for all 30 F5 Distributed Cloud (XC) service icons from @robinmordasiewicz/icons-f5xc.
+description: Visual reference for all 30 F5 Distributed Cloud (XC) service icons from @f5xc-salesdemos/icons-f5xc.
 sidebar:
   label: F5 XC
   order: 8
 ---
 
-import Icon from '@robinmordasiewicz/icons-f5xc/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-f5xc/Icon.astro';
 
-Complete visual reference for every icon in the [`@robinmordasiewicz/icons-f5xc`](https://www.npmjs.com/package/@robinmordasiewicz/icons-f5xc) package. These 30 icons represent F5 Distributed Cloud services and are available as Iconify JSON with an Astro component.
+Complete visual reference for every icon in the [`@f5xc-salesdemos/icons-f5xc`](https://www.npmjs.com/package/@f5xc-salesdemos/icons-f5xc) package. These 30 icons represent F5 Distributed Cloud services and are available as Iconify JSON with an Astro component.
 
 ## Usage
 
 ```astro
 ---
-import Icon from '@robinmordasiewicz/icons-f5xc/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-f5xc/Icon.astro';
 ---
 
 <Icon name="web-app-and-api-protection" size="2em" />
@@ -24,7 +24,7 @@ import Icon from '@robinmordasiewicz/icons-f5xc/Icon.astro';
 Or import the Iconify JSON directly:
 
 ```js
-import icons from '@robinmordasiewicz/icons-f5xc';
+import icons from '@f5xc-salesdemos/icons-f5xc';
 // icons.prefix === 'f5xc'
 // icons.icons['bot-defense'].body === '<svg body...>'
 ```

--- a/docs/hashicorp-flight.mdx
+++ b/docs/hashicorp-flight.mdx
@@ -1,20 +1,20 @@
 ---
 title: HashiCorp Flight Icons
-description: Visual reference for all 672 HashiCorp Flight icons from @robinmordasiewicz/icons-hashicorp-flight.
+description: Visual reference for all 672 HashiCorp Flight icons from @f5xc-salesdemos/icons-hashicorp-flight.
 sidebar:
   label: HashiCorp Flight
   order: 7
 ---
 
-import Icon from '@robinmordasiewicz/icons-hashicorp-flight/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-hashicorp-flight/Icon.astro';
 
-Complete visual reference for every icon in the [`@robinmordasiewicz/icons-hashicorp-flight`](https://www.npmjs.com/package/@robinmordasiewicz/icons-hashicorp-flight) package. Icons are rendered via the `Icon` component and organized by category.
+Complete visual reference for every icon in the [`@f5xc-salesdemos/icons-hashicorp-flight`](https://www.npmjs.com/package/@f5xc-salesdemos/icons-hashicorp-flight) package. Icons are rendered via the `Icon` component and organized by category.
 
 ## Usage
 
 ```astro
 ---
-import Icon from '@robinmordasiewicz/icons-hashicorp-flight/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-hashicorp-flight/Icon.astro';
 ---
 
 <Icon name="cloud" />

--- a/docs/iconify-packs.mdx
+++ b/docs/iconify-packs.mdx
@@ -6,10 +6,10 @@ sidebar:
   order: 6
 ---
 
-import MdiIcon from '@robinmordasiewicz/icons-mdi/Icon.astro';
-import CarbonIcon from '@robinmordasiewicz/icons-carbon/Icon.astro';
-import PhIcon from '@robinmordasiewicz/icons-phosphor/Icon.astro';
-import TablerIcon from '@robinmordasiewicz/icons-tabler/Icon.astro';
+import MdiIcon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
+import CarbonIcon from '@f5xc-salesdemos/icons-carbon/Icon.astro';
+import PhIcon from '@f5xc-salesdemos/icons-phosphor/Icon.astro';
+import TablerIcon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
 
 Multiple Iconify icon packs are available as npm packages with Astro `Icon` components. Each pack has its own import and uses the same `name`-based API.
 
@@ -28,10 +28,10 @@ Each pack has its own `Icon.astro` component:
 
 ```astro
 ---
-import MdiIcon from '@robinmordasiewicz/icons-mdi/Icon.astro';
-import CarbonIcon from '@robinmordasiewicz/icons-carbon/Icon.astro';
-import PhIcon from '@robinmordasiewicz/icons-phosphor/Icon.astro';
-import TablerIcon from '@robinmordasiewicz/icons-tabler/Icon.astro';
+import MdiIcon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
+import CarbonIcon from '@f5xc-salesdemos/icons-carbon/Icon.astro';
+import PhIcon from '@f5xc-salesdemos/icons-phosphor/Icon.astro';
+import TablerIcon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
 ---
 
 <MdiIcon name="database" />

--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -7,10 +7,10 @@ sidebar:
 ---
 
 import { Icon } from '@astrojs/starlight/components';
-import LucideIcon from '@robinmordasiewicz/icons-lucide/Icon.astro';
-import MdiIcon from '@robinmordasiewicz/icons-mdi/Icon.astro';
-import CarbonIcon from '@robinmordasiewicz/icons-carbon/Icon.astro';
-import TablerIcon from '@robinmordasiewicz/icons-tabler/Icon.astro';
+import LucideIcon from '@f5xc-salesdemos/icons-lucide/Icon.astro';
+import MdiIcon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
+import CarbonIcon from '@f5xc-salesdemos/icons-carbon/Icon.astro';
+import TablerIcon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
 
 The documentation theme provides access to thousands of icons from multiple packs. Every pack uses the same pattern: import the pack's `Icon.astro` component and reference icons by name.
 
@@ -42,9 +42,9 @@ All icon packs use per-package `Icon.astro` components that render inline SVGs. 
 import { Icon } from '@astrojs/starlight/components';
 
 // Other packs — each has its own import
-import LucideIcon from '@robinmordasiewicz/icons-lucide/Icon.astro';
-import MdiIcon from '@robinmordasiewicz/icons-mdi/Icon.astro';
-import F5xIcon from '@robinmordasiewicz/icons-f5xc/Icon.astro';
+import LucideIcon from '@f5xc-salesdemos/icons-lucide/Icon.astro';
+import MdiIcon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
+import F5xIcon from '@f5xc-salesdemos/icons-f5xc/Icon.astro';
 ---
 
 <Icon name="star" />

--- a/docs/lucide.mdx
+++ b/docs/lucide.mdx
@@ -6,15 +6,15 @@ sidebar:
   order: 5
 ---
 
-import Icon from '@robinmordasiewicz/icons-lucide/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-lucide/Icon.astro';
 
-[Lucide](https://lucide.dev/) provides ~1,600 modern, consistent stroke icons. Use the `Icon` component from `@robinmordasiewicz/icons-lucide` to render any icon by name.
+[Lucide](https://lucide.dev/) provides ~1,600 modern, consistent stroke icons. Use the `Icon` component from `@f5xc-salesdemos/icons-lucide` to render any icon by name.
 
 ## Usage
 
 ```astro
 ---
-import Icon from '@robinmordasiewicz/icons-lucide/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-lucide/Icon.astro';
 ---
 
 <Icon name="rocket" />

--- a/docs/simple-icons.mdx
+++ b/docs/simple-icons.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 7
 ---
 
-import SimpleIcon from '@robinmordasiewicz/icons-simple-icons/Icon.astro';
+import SimpleIcon from '@f5xc-salesdemos/icons-simple-icons/Icon.astro';
 
 Simple Icons provides 3,200+ free SVG icons for popular brands including network vendors, cloud providers, telecom companies, and technology services. All icons use a standard 24x24 viewBox.
 
@@ -14,7 +14,7 @@ Simple Icons provides 3,200+ free SVG icons for popular brands including network
 
 ```astro
 ---
-import SimpleIcon from '@robinmordasiewicz/icons-simple-icons/Icon.astro';
+import SimpleIcon from '@f5xc-salesdemos/icons-simple-icons/Icon.astro';
 ---
 
 <SimpleIcon name="cloudflare" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,54 @@
         "packages/*"
       ]
     },
+    "node_modules/@f5xc-salesdemos/icons-aws": {
+      "resolved": "packages/aws",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-azure": {
+      "resolved": "packages/azure",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-carbon": {
+      "resolved": "packages/carbon",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-f5-brand": {
+      "resolved": "packages/f5-brand",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-f5xc": {
+      "resolved": "packages/f5xc",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-gcp": {
+      "resolved": "packages/gcp",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-hashicorp-flight": {
+      "resolved": "packages/hashicorp-flight",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-lucide": {
+      "resolved": "packages/lucide",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-mdi": {
+      "resolved": "packages/mdi",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-phosphor": {
+      "resolved": "packages/phosphor",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-simple-icons": {
+      "resolved": "packages/simple-icons",
+      "link": true
+    },
+    "node_modules/@f5xc-salesdemos/icons-tabler": {
+      "resolved": "packages/tabler",
+      "link": true
+    },
     "node_modules/@hashicorp/flight-icons": {
       "version": "4.2.0",
       "license": "MPL-2.0"
@@ -63,54 +111,6 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "node_modules/@robinmordasiewicz/icons-aws": {
-      "resolved": "packages/aws",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-azure": {
-      "resolved": "packages/azure",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-carbon": {
-      "resolved": "packages/carbon",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-f5-brand": {
-      "resolved": "packages/f5-brand",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-f5xc": {
-      "resolved": "packages/f5xc",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-gcp": {
-      "resolved": "packages/gcp",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-hashicorp-flight": {
-      "resolved": "packages/hashicorp-flight",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-lucide": {
-      "resolved": "packages/lucide",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-mdi": {
-      "resolved": "packages/mdi",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-phosphor": {
-      "resolved": "packages/phosphor",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-simple-icons": {
-      "resolved": "packages/simple-icons",
-      "link": true
-    },
-    "node_modules/@robinmordasiewicz/icons-tabler": {
-      "resolved": "packages/tabler",
-      "link": true
-    },
     "node_modules/azureiconkento": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/azureiconkento/-/azureiconkento-1.2.1.tgz",
@@ -118,12 +118,12 @@
       "license": "https://learn.microsoft.com/ja-jp/azure/architecture/icons/"
     },
     "packages/aws": {
-      "name": "@robinmordasiewicz/icons-aws",
+      "name": "@f5xc-salesdemos/icons-aws",
       "version": "0.1.0",
       "license": "CC-BY-ND-2.0"
     },
     "packages/azure": {
-      "name": "@robinmordasiewicz/icons-azure",
+      "name": "@f5xc-salesdemos/icons-azure",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -131,7 +131,7 @@
       }
     },
     "packages/carbon": {
-      "name": "@robinmordasiewicz/icons-carbon",
+      "name": "@f5xc-salesdemos/icons-carbon",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -139,22 +139,22 @@
       }
     },
     "packages/f5-brand": {
-      "name": "@robinmordasiewicz/icons-f5-brand",
+      "name": "@f5xc-salesdemos/icons-f5-brand",
       "version": "0.2.0",
       "license": "MIT"
     },
     "packages/f5xc": {
-      "name": "@robinmordasiewicz/icons-f5xc",
+      "name": "@f5xc-salesdemos/icons-f5xc",
       "version": "0.3.2",
       "license": "MIT"
     },
     "packages/gcp": {
-      "name": "@robinmordasiewicz/icons-gcp",
+      "name": "@f5xc-salesdemos/icons-gcp",
       "version": "0.1.0",
       "license": "Apache-2.0"
     },
     "packages/hashicorp-flight": {
-      "name": "@robinmordasiewicz/icons-hashicorp-flight",
+      "name": "@f5xc-salesdemos/icons-hashicorp-flight",
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
@@ -162,7 +162,7 @@
       }
     },
     "packages/lucide": {
-      "name": "@robinmordasiewicz/icons-lucide",
+      "name": "@f5xc-salesdemos/icons-lucide",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -170,7 +170,7 @@
       }
     },
     "packages/mdi": {
-      "name": "@robinmordasiewicz/icons-mdi",
+      "name": "@f5xc-salesdemos/icons-mdi",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -178,7 +178,7 @@
       }
     },
     "packages/phosphor": {
-      "name": "@robinmordasiewicz/icons-phosphor",
+      "name": "@f5xc-salesdemos/icons-phosphor",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -186,7 +186,7 @@
       }
     },
     "packages/simple-icons": {
-      "name": "@robinmordasiewicz/icons-simple-icons",
+      "name": "@f5xc-salesdemos/icons-simple-icons",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -194,7 +194,7 @@
       }
     },
     "packages/tabler": {
-      "name": "@robinmordasiewicz/icons-tabler",
+      "name": "@f5xc-salesdemos/icons-tabler",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-aws",
+  "name": "@f5xc-salesdemos/icons-aws",
   "version": "0.1.0",
   "description": "AWS architecture icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-azure",
+  "name": "@f5xc-salesdemos/icons-azure",
   "version": "0.1.0",
   "description": "Azure architecture icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/carbon/package.json
+++ b/packages/carbon/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-carbon",
+  "name": "@f5xc-salesdemos/icons-carbon",
   "version": "0.2.0",
   "description": "Carbon Design icons with Astro component wrapper",
   "type": "module",

--- a/packages/f5-brand/package.json
+++ b/packages/f5-brand/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-f5-brand",
+  "name": "@f5xc-salesdemos/icons-f5-brand",
   "version": "0.2.0",
   "description": "F5 brand icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/f5xc/README.md
+++ b/packages/f5xc/README.md
@@ -1,4 +1,4 @@
-# @robinmordasiewicz/icons-f5xc
+# @f5xc-salesdemos/icons-f5xc
 
 F5 Distributed Cloud (XC) service icons in Iconify JSON format with an Astro component.
 
@@ -41,7 +41,7 @@ F5 Distributed Cloud (XC) service icons in Iconify JSON format with an Astro com
 
 ```astro
 ---
-import Icon from '@robinmordasiewicz/icons-f5xc/Icon.astro';
+import Icon from '@f5xc-salesdemos/icons-f5xc/Icon.astro';
 ---
 
 <Icon name="web-app-and-api-protection" size="2em" />
@@ -51,7 +51,7 @@ import Icon from '@robinmordasiewicz/icons-f5xc/Icon.astro';
 ## Usage (JSON)
 
 ```js
-import icons from '@robinmordasiewicz/icons-f5xc';
+import icons from '@f5xc-salesdemos/icons-f5xc';
 // icons.prefix === 'f5xc'
 // icons.icons['bot-defense'].body === '<svg body...>'
 ```

--- a/packages/f5xc/package.json
+++ b/packages/f5xc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-f5xc",
+  "name": "@f5xc-salesdemos/icons-f5xc",
   "version": "0.3.2",
   "description": "F5 Distributed Cloud (XC) service icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-gcp",
+  "name": "@f5xc-salesdemos/icons-gcp",
   "version": "0.1.0",
   "description": "Google Cloud architecture icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/hashicorp-flight/package.json
+++ b/packages/hashicorp-flight/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-hashicorp-flight",
+  "name": "@f5xc-salesdemos/icons-hashicorp-flight",
   "version": "0.3.0",
   "description": "HashiCorp Flight icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/lucide/package.json
+++ b/packages/lucide/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-lucide",
+  "name": "@f5xc-salesdemos/icons-lucide",
   "version": "0.2.0",
   "description": "Lucide icons with Astro component wrapper",
   "type": "module",

--- a/packages/mdi/package.json
+++ b/packages/mdi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-mdi",
+  "name": "@f5xc-salesdemos/icons-mdi",
   "version": "0.2.0",
   "description": "Material Design Icons with Astro component wrapper",
   "type": "module",

--- a/packages/phosphor/package.json
+++ b/packages/phosphor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-phosphor",
+  "name": "@f5xc-salesdemos/icons-phosphor",
   "version": "0.2.0",
   "description": "Phosphor icons with Astro component wrapper",
   "type": "module",

--- a/packages/simple-icons/package.json
+++ b/packages/simple-icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-simple-icons",
+  "name": "@f5xc-salesdemos/icons-simple-icons",
   "version": "0.1.0",
   "description": "Simple Icons brand icons in Iconify JSON format with Astro component",
   "type": "module",

--- a/packages/tabler/package.json
+++ b/packages/tabler/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robinmordasiewicz/icons-tabler",
+  "name": "@f5xc-salesdemos/icons-tabler",
   "version": "0.2.0",
   "description": "Tabler icons with Astro component wrapper",
   "type": "module",


### PR DESCRIPTION
## Summary
- Rename all 12 icon packages from `@robinmordasiewicz/icons-*` to `@f5xc-salesdemos/icons-*`
- Update all documentation references (8 .mdx files) and package README
- Regenerate `package-lock.json`

## Test plan
- [ ] Verify CI passes (lint, build)
- [ ] Verify npm publish succeeds under new scope after merge
- [ ] Confirm packages visible at `https://www.npmjs.com/org/f5xc-salesdemos`

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)