### PR TITLE
fix: apply canonical biome config and resolve lint/format issues

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,7 @@
       "exclude": [
         "repo\\b",
         "bug[- ]fix(es)?",
-        "build system"
+        "build system(s)?"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Repository Settings](https://github.com/f5xc-salesdemos/docs-icons/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-icons/actions/workflows/enforce-repo-settings.yml)
 [![License](https://img.shields.io/github/license/f5xc-salesdemos/docs-icons)](LICENSE)
 
-NPM icon packages and plugins for the F5 XC documentation build tool
+NPM icon packages and plugins for the F5 XC documentation build system
 
 ## Documentation
 

--- a/biome.json
+++ b/biome.json
@@ -1,15 +1,41 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
-  "files": {
-    "maxSize": 5242880,
-    "includes": ["**", "!packages/*/icons.json"]
-  },
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 120
   },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "css": {
+    "formatter": {
+      "enabled": false
+    }
+  },
   "linter": {
-    "enabled": false
-  }
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "files": {
+    "maxSize": 5242880,
+    "includes": ["**", "!packages/*/icons.json"]
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.astro"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/aws/BaseIcon.astro
+++ b/packages/aws/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/aws/Icon.astro
+++ b/packages/aws/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "./icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from './icons.json';
 
 interface Props {
   name: string;

--- a/packages/aws/scripts/build.mjs
+++ b/packages/aws/scripts/build.mjs
@@ -10,15 +10,15 @@
  * - License: CC-BY-ND 2.0
  */
 
-import { writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import https from "node:https";
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import https from 'node:https';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const outFile = join(__dirname, "..", "icons.json");
+const outFile = join(__dirname, '..', 'icons.json');
 
-const url = "https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/main/dist/aws-icons-mermaid.json";
+const url = 'https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/main/dist/aws-icons-mermaid.json';
 
 function fetch(href) {
   return new Promise((resolve, reject) => {
@@ -31,18 +31,18 @@ function fetch(href) {
           return reject(new Error(`HTTP ${res.statusCode} for ${href}`));
         }
         const chunks = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-        res.on("error", reject);
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        res.on('error', reject);
       })
-      .on("error", reject);
+      .on('error', reject);
   });
 }
 
 const raw = await fetch(url);
 const data = JSON.parse(raw);
 
-writeFileSync(outFile, JSON.stringify(data, null, 2) + "\n");
+writeFileSync(outFile, `${JSON.stringify(data, null, 2)}\n`);
 
 const count = Object.keys(data.icons).length;
 console.log(`Fetched ${count} AWS icons → ${outFile}`);

--- a/packages/azure/BaseIcon.astro
+++ b/packages/azure/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/azure/Icon.astro
+++ b/packages/azure/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "./icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from './icons.json';
 
 interface Props {
   name: string;

--- a/packages/azure/scripts/build.mjs
+++ b/packages/azure/scripts/build.mjs
@@ -11,17 +11,17 @@
  * - License: Microsoft Icon Terms
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
-const sourcePath = require.resolve("azureiconkento/azureicons/allicons.json");
-const source = JSON.parse(readFileSync(sourcePath, "utf8"));
-const outFile = join(__dirname, "..", "icons.json");
+const sourcePath = require.resolve('azureiconkento/azureicons/allicons.json');
+const source = JSON.parse(readFileSync(sourcePath, 'utf8'));
+const outFile = join(__dirname, '..', 'icons.json');
 
 const icons = {};
 
@@ -39,26 +39,26 @@ for (const [name, icon] of Object.entries(source.icons)) {
 
   for (const id of ids) {
     const safe = `az-${name}-${id}`;
-    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // Replace id="..." attribute
-    body = body.replace(new RegExp(`id="${escaped}"`, "g"), `id="${safe}"`);
+    body = body.replace(new RegExp(`id="${escaped}"`, 'g'), `id="${safe}"`);
     // Replace url(#...) references
-    body = body.replace(new RegExp(`url\\(#${escaped}\\)`, "g"), `url(#${safe})`);
+    body = body.replace(new RegExp(`url\\(#${escaped}\\)`, 'g'), `url(#${safe})`);
     // Replace href="#..." references (for <use> elements)
-    body = body.replace(new RegExp(`href="#${escaped}"`, "g"), `href="#${safe}"`);
+    body = body.replace(new RegExp(`href="#${escaped}"`, 'g'), `href="#${safe}"`);
   }
 
   icons[name] = { ...icon, body };
 }
 
 const output = {
-  prefix: "azure",
+  prefix: 'azure',
   width: source.width || 18,
   height: source.height || 18,
   icons,
 };
 
-writeFileSync(outFile, JSON.stringify(output, null, 2) + "\n");
+writeFileSync(outFile, `${JSON.stringify(output, null, 2)}\n`);
 
 const count = Object.keys(icons).length;
 console.log(`Built ${count} Azure icons (namespaced) → ${outFile}`);

--- a/packages/carbon/BaseIcon.astro
+++ b/packages/carbon/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/carbon/Icon.astro
+++ b/packages/carbon/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "@iconify-json/carbon/icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/carbon/icons.json';
 
 interface Props {
   name: string;

--- a/packages/carbon/scripts/build.mjs
+++ b/packages/carbon/scripts/build.mjs
@@ -5,16 +5,16 @@
  * so it can be exported alongside Icon.astro.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const source = require.resolve("@iconify-json/carbon/icons.json");
-const dest = join(__dirname, "..", "icons.json");
+const source = require.resolve('@iconify-json/carbon/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
 
-const data = JSON.parse(readFileSync(source, "utf8"));
-writeFileSync(dest, JSON.stringify(data, null, 2) + "\n");
+const data = JSON.parse(readFileSync(source, 'utf8'));
+writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 console.log(`Copied carbon icons.json → ${dest}`);

--- a/packages/f5-brand/BaseIcon.astro
+++ b/packages/f5-brand/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/f5-brand/Icon.astro
+++ b/packages/f5-brand/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "./icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from './icons.json';
 
 interface Props {
   name: string;

--- a/packages/f5-brand/scripts/build.mjs
+++ b/packages/f5-brand/scripts/build.mjs
@@ -11,16 +11,16 @@
  * - Reads viewBox dimensions from the <svg> element
  */
 
-import { readFileSync, writeFileSync, readdirSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const svgDir = join(__dirname, "..", "svg");
-const outFile = join(__dirname, "..", "icons.json");
+const svgDir = join(__dirname, '..', 'svg');
+const outFile = join(__dirname, '..', 'icons.json');
 
 const files = readdirSync(svgDir)
-  .filter((f) => f.endsWith(".svg"))
+  .filter((f) => f.endsWith('.svg'))
   .sort();
 
 const icons = {};
@@ -28,20 +28,20 @@ const skipped = [];
 
 for (const file of files) {
   // Skip bare ai-governance.svg — collides with f5-icon-ai-governance.svg
-  if (file === "ai-governance.svg") {
+  if (file === 'ai-governance.svg') {
     skipped.push(file);
     continue;
   }
 
   // Derive icon name: strip f5-icon- or f5- prefix, remove .svg extension
-  let name = basename(file, ".svg");
-  if (name.startsWith("f5-icon-")) {
-    name = name.slice("f5-icon-".length);
-  } else if (name.startsWith("f5-")) {
-    name = name.slice("f5-".length);
+  let name = basename(file, '.svg');
+  if (name.startsWith('f5-icon-')) {
+    name = name.slice('f5-icon-'.length);
+  } else if (name.startsWith('f5-')) {
+    name = name.slice('f5-'.length);
   }
 
-  const raw = readFileSync(join(svgDir, file), "utf8");
+  const raw = readFileSync(join(svgDir, file), 'utf8');
 
   // Extract viewBox dimensions
   const viewBoxMatch = raw.match(/viewBox="([^"]+)"/);
@@ -84,15 +84,15 @@ for (const file of files) {
 }
 
 const output = {
-  prefix: "f5-brand",
+  prefix: 'f5-brand',
   width: 50,
   height: 50,
   icons,
 };
 
-writeFileSync(outFile, JSON.stringify(output, null, 2) + "\n");
+writeFileSync(outFile, `${JSON.stringify(output, null, 2)}\n`);
 
 console.log(`Built ${Object.keys(icons).length} icons → ${outFile}`);
 if (skipped.length > 0) {
-  console.log(`Skipped ${skipped.length}: ${skipped.join(", ")}`);
+  console.log(`Skipped ${skipped.length}: ${skipped.join(', ')}`);
 }

--- a/packages/f5xc/BaseIcon.astro
+++ b/packages/f5xc/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/f5xc/Icon.astro
+++ b/packages/f5xc/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "./icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from './icons.json';
 
 interface Props {
   name: string;

--- a/packages/f5xc/scripts/build.mjs
+++ b/packages/f5xc/scripts/build.mjs
@@ -11,16 +11,16 @@
  * - Reads viewBox dimensions from the <svg> element
  */
 
-import { readFileSync, writeFileSync, readdirSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const svgDir = join(__dirname, "..", "svg");
-const outFile = join(__dirname, "..", "icons.json");
+const svgDir = join(__dirname, '..', 'svg');
+const outFile = join(__dirname, '..', 'icons.json');
 
 const files = readdirSync(svgDir)
-  .filter((f) => f.endsWith(".svg"))
+  .filter((f) => f.endsWith('.svg'))
   .sort();
 
 const icons = {};
@@ -28,14 +28,14 @@ const skipped = [];
 
 for (const file of files) {
   // Derive icon name: strip .svg, then clean up size suffixes
-  let name = basename(file, ".svg");
+  let name = basename(file, '.svg');
 
   // Remove size suffixes: -24x24, _24_x_24, -464-384, etc.
-  name = name.replace(/[-_]\d+[-x_]+\d+$/i, "");
+  name = name.replace(/[-_]\d+[-x_]+\d+$/i, '');
   // Remove trailing -image if present (e.g. platform-image)
-  name = name.replace(/-image$/, "");
+  name = name.replace(/-image$/, '');
 
-  const raw = readFileSync(join(svgDir, file), "utf8");
+  const raw = readFileSync(join(svgDir, file), 'utf8');
 
   // Extract viewBox dimensions
   const viewBoxMatch = raw.match(/viewBox="([^"]+)"/);
@@ -101,15 +101,15 @@ for (const file of files) {
 }
 
 const output = {
-  prefix: "f5xc",
+  prefix: 'f5xc',
   width: 40,
   height: 40,
   icons,
 };
 
-writeFileSync(outFile, JSON.stringify(output, null, 2) + "\n");
+writeFileSync(outFile, `${JSON.stringify(output, null, 2)}\n`);
 
 console.log(`Built ${Object.keys(icons).length} icons → ${outFile}`);
 if (skipped.length > 0) {
-  console.log(`Skipped ${skipped.length}: ${skipped.join(", ")}`);
+  console.log(`Skipped ${skipped.length}: ${skipped.join(', ')}`);
 }

--- a/packages/gcp/BaseIcon.astro
+++ b/packages/gcp/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/gcp/Icon.astro
+++ b/packages/gcp/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "./icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from './icons.json';
 
 interface Props {
   name: string;

--- a/packages/gcp/scripts/build.mjs
+++ b/packages/gcp/scripts/build.mjs
@@ -10,22 +10,22 @@
  * - License: Apache-2.0
  */
 
-import { writeFileSync, mkdtempSync, rmSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { dirname, join, basename } from "node:path";
-import { fileURLToPath } from "node:url";
-import { tmpdir } from "node:os";
-import https from "node:https";
-import { execSync } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import https from 'node:https';
+import { execSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const outFile = join(__dirname, "..", "icons.json");
+const outFile = join(__dirname, '..', 'icons.json');
 
-const zipUrl = "https://github.com/AwesomeLogos/google-cloud-icons/archive/refs/heads/main.zip";
+const zipUrl = 'https://github.com/AwesomeLogos/google-cloud-icons/archive/refs/heads/main.zip';
 
 function fetch(href) {
   return new Promise((resolve, reject) => {
     https
-      .get(href, { headers: { "User-Agent": "docs-icons-build" } }, (res) => {
+      .get(href, { headers: { 'User-Agent': 'docs-icons-build' } }, (res) => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           return fetch(res.headers.location).then(resolve, reject);
         }
@@ -33,11 +33,11 @@ function fetch(href) {
           return reject(new Error(`HTTP ${res.statusCode} for ${href}`));
         }
         const chunks = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => resolve(Buffer.concat(chunks)));
-        res.on("error", reject);
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+        res.on('error', reject);
       })
-      .on("error", reject);
+      .on('error', reject);
   });
 }
 
@@ -48,29 +48,30 @@ function fetch(href) {
 function parseStyleBlock(styleContent) {
   const mappings = {};
   const ruleRegex = /([^{}]+)\{([^}]+)\}/g;
-  let match;
-  while ((match = ruleRegex.exec(styleContent)) !== null) {
+  let match = ruleRegex.exec(styleContent);
+  while (match !== null) {
     const selectors = match[1].trim();
     const declarations = match[2].trim();
 
     // Parse all declarations into property map
     const props = {};
-    for (const decl of declarations.split(";")) {
-      const colonIdx = decl.indexOf(":");
+    for (const decl of declarations.split(';')) {
+      const colonIdx = decl.indexOf(':');
       if (colonIdx === -1) continue;
       const prop = decl.slice(0, colonIdx).trim();
       const val = decl.slice(colonIdx + 1).trim();
       if (prop && val) props[prop] = val;
     }
 
-    if (Object.keys(props).length === 0) continue;
-
-    for (const sel of selectors.split(",")) {
-      const clsMatch = sel.trim().match(/^\.([\w-]+)$/);
-      if (clsMatch) {
-        mappings[clsMatch[1]] = props;
+    if (Object.keys(props).length > 0) {
+      for (const sel of selectors.split(',')) {
+        const clsMatch = sel.trim().match(/^\.([\w-]+)$/);
+        if (clsMatch) {
+          mappings[clsMatch[1]] = props;
+        }
       }
     }
+    match = ruleRegex.exec(styleContent);
   }
   return mappings;
 }
@@ -96,12 +97,12 @@ function inlineStyles(svgContent) {
     // Build inline attribute string from CSS properties
     const attrs = Object.entries(props)
       .map(([prop, val]) => `${prop}="${val}"`)
-      .join(" ");
+      .join(' ');
 
     // Handle class="cls-N" (single class)
-    result = result.replace(new RegExp(`class="${cls}"`, "g"), attrs);
+    result = result.replace(new RegExp(`class="${cls}"`, 'g'), attrs);
     // Handle class="cls-N cls-M" (multiple classes)
-    result = result.replace(new RegExp(`class="([^"]*\\b)${cls}(\\b[^"]*)"`, "g"), (match, before, after) => {
+    result = result.replace(new RegExp(`class="([^"]*\\b)${cls}(\\b[^"]*)"`, 'g'), (_match, before, after) => {
       const remaining = `${before}${after}`.trim();
       if (remaining) {
         return `${attrs} class="${remaining}"`;
@@ -111,17 +112,17 @@ function inlineStyles(svgContent) {
   }
 
   // Remove <style> block (and containing <defs> if it only holds <style>)
-  result = result.replace(/<defs>\s*<style[^>]*>[\s\S]*?<\/style>\s*<\/defs>/gi, "");
-  result = result.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
+  result = result.replace(/<defs>\s*<style[^>]*>[\s\S]*?<\/style>\s*<\/defs>/gi, '');
+  result = result.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
 
   return result;
 }
 
-console.log("Downloading GCP icon archive...");
+console.log('Downloading GCP icon archive...');
 const zipBuffer = await fetch(zipUrl);
 
-const tmpDir = mkdtempSync(join(tmpdir(), "gcp-icons-"));
-const zipFile = join(tmpDir, "gcp-icons.zip");
+const tmpDir = mkdtempSync(join(tmpdir(), 'gcp-icons-'));
+const zipFile = join(tmpDir, 'gcp-icons.zip');
 writeFileSync(zipFile, zipBuffer);
 
 execSync(`unzip -q "${zipFile}" -d "${tmpDir}"`);
@@ -129,29 +130,29 @@ execSync(`unzip -q "${zipFile}" -d "${tmpDir}"`);
 // Find the extracted directory
 const extractedDir = readdirSync(tmpDir).find((d) => {
   try {
-    return statSync(join(tmpDir, d)).isDirectory() && d.startsWith("google-cloud-icons");
+    return statSync(join(tmpDir, d)).isDirectory() && d.startsWith('google-cloud-icons');
   } catch {
     return false;
   }
 });
 
 if (!extractedDir) {
-  console.error("Could not find extracted directory");
+  console.error('Could not find extracted directory');
   rmSync(tmpDir, { recursive: true });
   process.exit(1);
 }
 
 // SVGs are flat files in docs/images/
-const imagesDir = join(tmpDir, extractedDir, "docs", "images");
+const imagesDir = join(tmpDir, extractedDir, 'docs', 'images');
 const svgFiles = readdirSync(imagesDir)
-  .filter((f) => f.endsWith(".svg"))
+  .filter((f) => f.endsWith('.svg'))
   .sort();
 
 const icons = {};
 const skipped = [];
 
 for (const file of svgFiles) {
-  const raw = readFileSync(join(imagesDir, file), "utf8");
+  const raw = readFileSync(join(imagesDir, file), 'utf8');
 
   // Inline CSS styles to prevent cross-icon class conflicts
   const processed = inlineStyles(raw);
@@ -178,7 +179,7 @@ for (const file of svgFiles) {
   const body = bodyMatch[1].trim();
 
   // Derive icon name: strip .svg, underscores → hyphens, lowercase
-  const name = basename(file, ".svg").replace(/_/g, "-").toLowerCase();
+  const name = basename(file, '.svg').replace(/_/g, '-').toLowerCase();
 
   if (icons[name]) {
     console.log(`SKIP duplicate name "${name}" from ${file}`);
@@ -192,16 +193,16 @@ for (const file of svgFiles) {
 rmSync(tmpDir, { recursive: true });
 
 const output = {
-  prefix: "gcp",
+  prefix: 'gcp',
   width: 24,
   height: 24,
   icons,
 };
 
-writeFileSync(outFile, JSON.stringify(output, null, 2) + "\n");
+writeFileSync(outFile, `${JSON.stringify(output, null, 2)}\n`);
 
 const count = Object.keys(icons).length;
 console.log(`Built ${count} GCP icons → ${outFile}`);
 if (skipped.length > 0) {
-  console.log(`Skipped ${skipped.length}: ${skipped.join(", ")}`);
+  console.log(`Skipped ${skipped.length}: ${skipped.join(', ')}`);
 }

--- a/packages/hashicorp-flight/BaseIcon.astro
+++ b/packages/hashicorp-flight/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/hashicorp-flight/Icon.astro
+++ b/packages/hashicorp-flight/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "./icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from './icons.json';
 
 interface Props {
   name: string;

--- a/packages/hashicorp-flight/scripts/build.mjs
+++ b/packages/hashicorp-flight/scripts/build.mjs
@@ -10,21 +10,21 @@
  * - Extracts SVG body (content between <svg> tags)
  */
 
-import { readFileSync, writeFileSync, readdirSync } from "node:fs";
-import { join, basename, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 // Resolve the flight-icons package SVG directory
-const flightIconsDir = join(dirname(require.resolve("@hashicorp/flight-icons/package.json")), "svg");
+const flightIconsDir = join(dirname(require.resolve('@hashicorp/flight-icons/package.json')), 'svg');
 
-const outFile = join(__dirname, "..", "icons.json");
+const outFile = join(__dirname, '..', 'icons.json');
 
 const files = readdirSync(flightIconsDir)
-  .filter((f) => f.endsWith("-24.svg"))
+  .filter((f) => f.endsWith('-24.svg'))
   .sort();
 
 const icons = {};
@@ -32,9 +32,9 @@ const skipped = [];
 
 for (const file of files) {
   // Derive icon name: strip -24.svg suffix
-  const name = basename(file, "-24.svg");
+  const name = basename(file, '-24.svg');
 
-  const raw = readFileSync(join(flightIconsDir, file), "utf8");
+  const raw = readFileSync(join(flightIconsDir, file), 'utf8');
 
   // Extract viewBox dimensions (default 24x24)
   const viewBoxMatch = raw.match(/viewBox="([^"]+)"/);
@@ -65,7 +65,7 @@ for (const file of files) {
 // Custom icons not available in @hashicorp/flight-icons
 // ---------------------------------------------------------------------------
 const customIcons = {
-  "instagram-color": {
+  'instagram-color': {
     body: '<path fill="url(#instagram-color-24__ig0)" d="M7.0301.084c-1.2768.0602-2.1487.264-2.911.5634-.7888.3075-1.4575.72-2.1228 1.3877-.6652.6677-1.075 1.3368-1.3802 2.127-.2954.7638-.4956 1.6365-.552 2.914-.0564 1.2775-.0689 1.6882-.0626 4.947.0062 3.2586.0206 3.6671.0825 4.9473.061 1.2765.264 2.1482.5635 2.9107.308.7889.72 1.4573 1.388 2.1228.6679.6655 1.3365 1.0743 2.1285 1.38.7632.295 1.6361.4961 2.9134.552 1.2773.056 1.6884.069 4.9462.0627 3.2578-.0062 3.668-.0207 4.9478-.0814 1.28-.0607 2.147-.2652 2.9098-.5633.7889-.3086 1.4578-.72 2.1228-1.3881.665-.6682 1.0745-1.3378 1.3795-2.1284.2957-.7632.4966-1.636.552-2.9124.056-1.2809.0692-1.6898.063-4.948-.0063-3.2583-.021-3.6668-.0817-4.9465-.0607-1.2797-.264-2.1487-.5633-2.9117-.3084-.7889-.72-1.4568-1.3876-2.1228C21.2982 1.33 20.628.9208 19.8378.6165 19.074.321 18.2017.1197 16.9244.0645 15.6471.0093 15.236-.005 11.977.0014 8.718.0076 8.31.0215 7.0301.0839m.1402 21.6932c-1.17-.0509-1.8053-.2453-2.2287-.408-.5606-.216-.96-.4771-1.3819-.895-.422-.4178-.6811-.8186-.9-1.378-.1644-.4234-.3624-1.058-.4171-2.228-.0595-1.2645-.072-1.6442-.079-4.848-.007-3.2037.0053-3.583.0607-4.848.05-1.169.2456-1.805.408-2.2282.216-.5613.4762-.96.895-1.3816.4188-.4217.8184-.6814 1.3783-.9003.423-.1651 1.0575-.3614 2.227-.4171 1.2655-.06 1.6447-.072 4.848-.079 3.2033-.007 3.5835.005 4.8495.0608 1.169.0508 1.8053.2445 2.228.408.5608.216.96.4754 1.3816.895.4217.4194.6816.8176.9005 1.3787.1653.4217.3617 1.056.4169 2.2263.0602 1.2655.0739 1.645.0796 4.848.0058 3.203-.0055 3.5834-.061 4.848-.051 1.17-.245 1.8055-.408 2.2294-.216.5604-.4763.96-.8954 1.3814-.419.4215-.8181.6811-1.3783.9-.4224.1649-1.0577.3617-2.2262.4174-1.2656.0595-1.6448.072-4.8493.079-3.2045.007-3.5825-.006-4.848-.0608M16.953 5.5864A1.44 1.44 0 1 0 18.39 4.144a1.44 1.44 0 0 0-1.437 1.4424M5.8385 12.012c.0067 3.4032 2.7706 6.1557 6.173 6.1493 3.4026-.0065 6.157-2.7701 6.1506-6.1733-.0065-3.4032-2.771-6.1565-6.174-6.1498-3.403.0067-6.156 2.771-6.1496 6.1738M8 12.0077a4 4 0 1 1 4.008 3.9921A3.9996 3.9996 0 0 1 8 12.0077"/><defs><radialGradient id="instagram-color-24__ig0" cx=".25" cy="1.07" r="1.5" fx=".25" fy="1.07"><stop offset="0" stop-color="#fdf497"/><stop offset=".05" stop-color="#fdf497"/><stop offset=".45" stop-color="#fd5949"/><stop offset=".6" stop-color="#d6249f"/><stop offset=".9" stop-color="#285AEB"/></radialGradient></defs>',
     width: 24,
     height: 24,
@@ -83,18 +83,18 @@ for (const [name, data] of Object.entries(customIcons)) {
 }
 
 const output = {
-  prefix: "hashicorp-flight",
+  prefix: 'hashicorp-flight',
   width: 24,
   height: 24,
   icons,
 };
 
-writeFileSync(outFile, JSON.stringify(output, null, 2) + "\n");
+writeFileSync(outFile, `${JSON.stringify(output, null, 2)}\n`);
 
 console.log(`Built ${Object.keys(icons).length} icons → ${outFile}`);
 if (customCount > 0) {
-  console.log(`  (includes ${customCount} custom icon${customCount > 1 ? "s" : ""})`);
+  console.log(`  (includes ${customCount} custom icon${customCount > 1 ? 's' : ''})`);
 }
 if (skipped.length > 0) {
-  console.log(`Skipped ${skipped.length}: ${skipped.join(", ")}`);
+  console.log(`Skipped ${skipped.length}: ${skipped.join(', ')}`);
 }

--- a/packages/lucide/BaseIcon.astro
+++ b/packages/lucide/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/lucide/Icon.astro
+++ b/packages/lucide/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "@iconify-json/lucide/icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/lucide/icons.json';
 
 interface Props {
   name: string;

--- a/packages/lucide/scripts/build.mjs
+++ b/packages/lucide/scripts/build.mjs
@@ -5,16 +5,16 @@
  * so it can be exported alongside Icon.astro.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const source = require.resolve("@iconify-json/lucide/icons.json");
-const dest = join(__dirname, "..", "icons.json");
+const source = require.resolve('@iconify-json/lucide/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
 
-const data = JSON.parse(readFileSync(source, "utf8"));
-writeFileSync(dest, JSON.stringify(data, null, 2) + "\n");
+const data = JSON.parse(readFileSync(source, 'utf8'));
+writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 console.log(`Copied lucide icons.json → ${dest}`);

--- a/packages/mdi/BaseIcon.astro
+++ b/packages/mdi/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/mdi/Icon.astro
+++ b/packages/mdi/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "@iconify-json/mdi/icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/mdi/icons.json';
 
 interface Props {
   name: string;

--- a/packages/mdi/scripts/build.mjs
+++ b/packages/mdi/scripts/build.mjs
@@ -5,16 +5,16 @@
  * so it can be exported alongside Icon.astro.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const source = require.resolve("@iconify-json/mdi/icons.json");
-const dest = join(__dirname, "..", "icons.json");
+const source = require.resolve('@iconify-json/mdi/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
 
-const data = JSON.parse(readFileSync(source, "utf8"));
-writeFileSync(dest, JSON.stringify(data, null, 2) + "\n");
+const data = JSON.parse(readFileSync(source, 'utf8'));
+writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 console.log(`Copied mdi icons.json → ${dest}`);

--- a/packages/phosphor/BaseIcon.astro
+++ b/packages/phosphor/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/phosphor/Icon.astro
+++ b/packages/phosphor/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "@iconify-json/ph/icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/ph/icons.json';
 
 interface Props {
   name: string;

--- a/packages/phosphor/scripts/build.mjs
+++ b/packages/phosphor/scripts/build.mjs
@@ -5,16 +5,16 @@
  * so it can be exported alongside Icon.astro.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const source = require.resolve("@iconify-json/ph/icons.json");
-const dest = join(__dirname, "..", "icons.json");
+const source = require.resolve('@iconify-json/ph/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
 
-const data = JSON.parse(readFileSync(source, "utf8"));
-writeFileSync(dest, JSON.stringify(data, null, 2) + "\n");
+const data = JSON.parse(readFileSync(source, 'utf8'));
+writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 console.log(`Copied phosphor icons.json → ${dest}`);

--- a/packages/simple-icons/BaseIcon.astro
+++ b/packages/simple-icons/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/simple-icons/Icon.astro
+++ b/packages/simple-icons/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "@iconify-json/simple-icons/icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/simple-icons/icons.json';
 
 interface Props {
   name: string;

--- a/packages/simple-icons/scripts/build.mjs
+++ b/packages/simple-icons/scripts/build.mjs
@@ -5,16 +5,16 @@
  * so it can be exported alongside Icon.astro.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const source = require.resolve("@iconify-json/simple-icons/icons.json");
-const dest = join(__dirname, "..", "icons.json");
+const source = require.resolve('@iconify-json/simple-icons/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
 
-const data = JSON.parse(readFileSync(source, "utf8"));
-writeFileSync(dest, JSON.stringify(data, null, 2) + "\n");
+const data = JSON.parse(readFileSync(source, 'utf8'));
+writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 console.log(`Copied simple-icons icons.json \u2192 ${dest}`);

--- a/packages/tabler/BaseIcon.astro
+++ b/packages/tabler/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 

--- a/packages/tabler/Icon.astro
+++ b/packages/tabler/Icon.astro
@@ -1,6 +1,6 @@
 ---
-import BaseIcon from "./BaseIcon.astro";
-import iconData from "@iconify-json/tabler/icons.json";
+import BaseIcon from './BaseIcon.astro';
+import iconData from '@iconify-json/tabler/icons.json';
 
 interface Props {
   name: string;

--- a/packages/tabler/scripts/build.mjs
+++ b/packages/tabler/scripts/build.mjs
@@ -5,16 +5,16 @@
  * so it can be exported alongside Icon.astro.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const source = require.resolve("@iconify-json/tabler/icons.json");
-const dest = join(__dirname, "..", "icons.json");
+const source = require.resolve('@iconify-json/tabler/icons.json');
+const dest = join(__dirname, '..', 'icons.json');
 
-const data = JSON.parse(readFileSync(source, "utf8"));
-writeFileSync(dest, JSON.stringify(data, null, 2) + "\n");
+const data = JSON.parse(readFileSync(source, 'utf8'));
+writeFileSync(dest, `${JSON.stringify(data, null, 2)}\n`);
 console.log(`Copied tabler icons.json → ${dest}`);

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -17,26 +17,26 @@
  * - aws: from awslabs/aws-icons-for-plantuml
  */
 
-import { execSync } from "node:child_process";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { execSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = join(__dirname, "..");
+const root = join(__dirname, '..');
 
 const builds = [
-  { name: "f5-brand", script: "packages/f5-brand/scripts/build.mjs" },
-  { name: "hashicorp-flight", script: "packages/hashicorp-flight/scripts/build.mjs" },
-  { name: "f5xc", script: "packages/f5xc/scripts/build.mjs" },
-  { name: "lucide", script: "packages/lucide/scripts/build.mjs" },
-  { name: "carbon", script: "packages/carbon/scripts/build.mjs" },
-  { name: "mdi", script: "packages/mdi/scripts/build.mjs" },
-  { name: "phosphor", script: "packages/phosphor/scripts/build.mjs" },
-  { name: "tabler", script: "packages/tabler/scripts/build.mjs" },
-  { name: "simple-icons", script: "packages/simple-icons/scripts/build.mjs" },
-  { name: "aws", script: "packages/aws/scripts/build.mjs" },
-  { name: "azure", script: "packages/azure/scripts/build.mjs" },
-  { name: "gcp", script: "packages/gcp/scripts/build.mjs" },
+  { name: 'f5-brand', script: 'packages/f5-brand/scripts/build.mjs' },
+  { name: 'hashicorp-flight', script: 'packages/hashicorp-flight/scripts/build.mjs' },
+  { name: 'f5xc', script: 'packages/f5xc/scripts/build.mjs' },
+  { name: 'lucide', script: 'packages/lucide/scripts/build.mjs' },
+  { name: 'carbon', script: 'packages/carbon/scripts/build.mjs' },
+  { name: 'mdi', script: 'packages/mdi/scripts/build.mjs' },
+  { name: 'phosphor', script: 'packages/phosphor/scripts/build.mjs' },
+  { name: 'tabler', script: 'packages/tabler/scripts/build.mjs' },
+  { name: 'simple-icons', script: 'packages/simple-icons/scripts/build.mjs' },
+  { name: 'aws', script: 'packages/aws/scripts/build.mjs' },
+  { name: 'azure', script: 'packages/azure/scripts/build.mjs' },
+  { name: 'gcp', script: 'packages/gcp/scripts/build.mjs' },
 ];
 
 let failed = false;
@@ -44,16 +44,16 @@ let failed = false;
 for (const { name, script } of builds) {
   console.log(`\n--- Building ${name} ---`);
   try {
-    execSync(`node ${join(root, script)}`, { stdio: "inherit", cwd: root });
-  } catch (err) {
+    execSync(`node ${join(root, script)}`, { stdio: 'inherit', cwd: root });
+  } catch (_err) {
     console.error(`FAILED: ${name}`);
     failed = true;
   }
 }
 
 if (failed) {
-  console.error("\nSome builds failed.");
+  console.error('\nSome builds failed.');
   process.exit(1);
 } else {
-  console.log("\nAll builds succeeded.");
+  console.log('\nAll builds succeeded.');
 }

--- a/shared/BaseIcon.astro
+++ b/shared/BaseIcon.astro
@@ -9,11 +9,11 @@ interface Props {
   class?: string;
 }
 
-const { name, icons, defaultWidth = 24, defaultHeight = 24, size = "1.5em", label, class: className } = Astro.props;
+const { name, icons, defaultWidth = 24, defaultHeight = 24, size = '1.5em', label, class: className } = Astro.props;
 
 const icon = icons[name];
 if (!icon) {
-  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(", ")}...`);
+  throw new Error(`Unknown icon "${name}". Available icons: ${Object.keys(icons).slice(0, 10).join(', ')}...`);
 }
 ---
 


### PR DESCRIPTION
## Summary
- Syncs `biome.json`, `.textlintrc`, and `README.md` with canonical versions from docs-control
- Runs biome format across all packages (double → single quotes, 38 files)
- Applies biome lint --fix for `useTemplate` and `noUnusedVariables` in build scripts
- Manually fixes `noAssignInExpressions` in `packages/gcp/scripts/build.mjs` by refactoring while-loop assignment pattern

## Test plan
- [x] `npx @biomejs/biome@2.3.14 lint .` — zero errors/warnings
- [x] `npx @biomejs/biome@2.3.14 format .` — zero fixes needed
- [ ] CI super-linter passes (BIOME_FORMAT + BIOME_LINT)
- [ ] All other CI checks pass

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)