### PR TITLE
docs: break out icon pack documentation into standalone pages

### DIFF
--- a/docs/aws.mdx
+++ b/docs/aws.mdx
@@ -1,0 +1,126 @@
+---
+title: AWS Architecture Icons
+description: Curated reference for AWS Architecture Icons — 885 color service icons for cloud infrastructure diagrams and documentation.
+sidebar:
+  label: AWS
+  order: 14
+---
+
+import Icon from '@f5xc-salesdemos/icons-aws/Icon.astro';
+
+[AWS Architecture Icons](https://aws.amazon.com/architecture/icons/) provides 885 color service icons for documenting AWS infrastructure. Use the `Icon` component from `@f5xc-salesdemos/icons-aws` to render any icon by name. Default size is 48x48 with per-icon size overrides.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-aws/Icon.astro';
+---
+
+<Icon name="lambda" />
+<Icon name="ec2" size="2rem" />
+<Icon name="vpc" size="1.5rem" label="VPC" />
+```
+
+These icons use original vendor colors (not `currentColor`). Colors are embedded in the SVG markup and preserved in both light and dark mode.
+
+## Compute
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ec2" size="1.5rem" /></div><div class="icon-card-label">ec2</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lambda" size="1.5rem" /></div><div class="icon-card-label">lambda</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="elastic-container-service" size="1.5rem" /></div><div class="icon-card-label">elastic-container-service</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="elastic-kubernetes-service" size="1.5rem" /></div><div class="icon-card-label">elastic-kubernetes-service</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="fargate" size="1.5rem" /></div><div class="icon-card-label">fargate</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ec2-auto-scaling" size="1.5rem" /></div><div class="icon-card-label">ec2-auto-scaling</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="elastic-beanstalk" size="1.5rem" /></div><div class="icon-card-label">elastic-beanstalk</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="app-runner" size="1.5rem" /></div><div class="icon-card-label">app-runner</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="batch" size="1.5rem" /></div><div class="icon-card-label">batch</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="outposts-rack" size="1.5rem" /></div><div class="icon-card-label">outposts-rack</div></div>
+</div>
+
+## Networking
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="vpc" size="1.5rem" /></div><div class="icon-card-label">vpc</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloudfront" size="1.5rem" /></div><div class="icon-card-label">cloudfront</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="route-53" size="1.5rem" /></div><div class="icon-card-label">route-53</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="elastic-load-balancing" size="1.5rem" /></div><div class="icon-card-label">elastic-load-balancing</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="api-gateway" size="1.5rem" /></div><div class="icon-card-label">api-gateway</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="app-mesh" size="1.5rem" /></div><div class="icon-card-label">app-mesh</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="global-accelerator" size="1.5rem" /></div><div class="icon-card-label">global-accelerator</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="direct-connect" size="1.5rem" /></div><div class="icon-card-label">direct-connect</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="transit-gateway" size="1.5rem" /></div><div class="icon-card-label">transit-gateway</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-wan" size="1.5rem" /></div><div class="icon-card-label">cloud-wan</div></div>
+</div>
+
+## Storage &amp; Database
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="simple-storage-service" size="1.5rem" /></div><div class="icon-card-label">simple-storage-service</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="dynamodb" size="1.5rem" /></div><div class="icon-card-label">dynamodb</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="aurora" size="1.5rem" /></div><div class="icon-card-label">aurora</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="rds" size="1.5rem" /></div><div class="icon-card-label">rds</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="elasticache" size="1.5rem" /></div><div class="icon-card-label">elasticache</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="redshift" size="1.5rem" /></div><div class="icon-card-label">redshift</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="elastic-block-store" size="1.5rem" /></div><div class="icon-card-label">elastic-block-store</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="efs" size="1.5rem" /></div><div class="icon-card-label">efs</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="documentdb" size="1.5rem" /></div><div class="icon-card-label">documentdb</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="neptune" size="1.5rem" /></div><div class="icon-card-label">neptune</div></div>
+</div>
+
+## Security
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="waf" size="1.5rem" /></div><div class="icon-card-label">waf</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cognito" size="1.5rem" /></div><div class="icon-card-label">cognito</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="iam-identity-center" size="1.5rem" /></div><div class="icon-card-label">iam-identity-center</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="certificate-manager" size="1.5rem" /></div><div class="icon-card-label">certificate-manager</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="secrets-manager" size="1.5rem" /></div><div class="icon-card-label">secrets-manager</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="guardduty" size="1.5rem" /></div><div class="icon-card-label">guardduty</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="inspector" size="1.5rem" /></div><div class="icon-card-label">inspector</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="security-hub" size="1.5rem" /></div><div class="icon-card-label">security-hub</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="network-firewall" size="1.5rem" /></div><div class="icon-card-label">network-firewall</div></div>
+</div>
+
+## Application Integration
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="simple-queue-service" size="1.5rem" /></div><div class="icon-card-label">simple-queue-service</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="simple-notification-service" size="1.5rem" /></div><div class="icon-card-label">simple-notification-service</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="eventbridge" size="1.5rem" /></div><div class="icon-card-label">eventbridge</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="step-functions" size="1.5rem" /></div><div class="icon-card-label">step-functions</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="appflow" size="1.5rem" /></div><div class="icon-card-label">appflow</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="appsync" size="1.5rem" /></div><div class="icon-card-label">appsync</div></div>
+</div>
+
+## Management &amp; Governance
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloudformation" size="1.5rem" /></div><div class="icon-card-label">cloudformation</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloudwatch" size="1.5rem" /></div><div class="icon-card-label">cloudwatch</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloudtrail" size="1.5rem" /></div><div class="icon-card-label">cloudtrail</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="config" size="1.5rem" /></div><div class="icon-card-label">config</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="systems-manager" size="1.5rem" /></div><div class="icon-card-label">systems-manager</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="organizations" size="1.5rem" /></div><div class="icon-card-label">organizations</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="control-tower" size="1.5rem" /></div><div class="icon-card-label">control-tower</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="trusted-advisor" size="1.5rem" /></div><div class="icon-card-label">trusted-advisor</div></div>
+</div>
+
+## AI &amp; ML
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bedrock" size="1.5rem" /></div><div class="icon-card-label">bedrock</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="sagemaker" size="1.5rem" /></div><div class="icon-card-label">sagemaker</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="rekognition" size="1.5rem" /></div><div class="icon-card-label">rekognition</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="comprehend" size="1.5rem" /></div><div class="icon-card-label">comprehend</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lex" size="1.5rem" /></div><div class="icon-card-label">lex</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="polly" size="1.5rem" /></div><div class="icon-card-label">polly</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="textract" size="1.5rem" /></div><div class="icon-card-label">textract</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="translate" size="1.5rem" /></div><div class="icon-card-label">translate</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 885 AWS Architecture Icons, visit [AWS Icons for Architecture Diagrams](https://aws.amazon.com/architecture/icons/).

--- a/docs/azure.mdx
+++ b/docs/azure.mdx
@@ -1,0 +1,107 @@
+---
+title: Azure Architecture Icons
+description: Curated reference for Azure Architecture Icons — 606 color service icons for cloud infrastructure diagrams and documentation.
+sidebar:
+  label: Azure
+  order: 15
+---
+
+import Icon from '@f5xc-salesdemos/icons-azure/Icon.astro';
+
+[Azure Architecture Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/) provides 606 color service icons for documenting Azure infrastructure. Use the `Icon` component from `@f5xc-salesdemos/icons-azure` to render any icon by name. Default size is 18x18 with gradient fills.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-azure/Icon.astro';
+---
+
+<Icon name="virtual-machine" />
+<Icon name="kubernetes-services" size="2rem" />
+<Icon name="load-balancers" size="1.5rem" label="Load Balancer" />
+```
+
+These icons use original vendor colors (not `currentColor`). Colors are embedded in the SVG markup and preserved in both light and dark mode.
+
+## Compute
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="virtual-machine" size="1.5rem" /></div><div class="icon-card-label">virtual-machine</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="function-apps" size="1.5rem" /></div><div class="icon-card-label">function-apps</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="kubernetes-services" size="1.5rem" /></div><div class="icon-card-label">kubernetes-services</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="app-services" size="1.5rem" /></div><div class="icon-card-label">app-services</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="container-instances" size="1.5rem" /></div><div class="icon-card-label">container-instances</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="container-registries" size="1.5rem" /></div><div class="icon-card-label">container-registries</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="vm-scale-sets" size="1.5rem" /></div><div class="icon-card-label">vm-scale-sets</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="batch-accounts" size="1.5rem" /></div><div class="icon-card-label">batch-accounts</div></div>
+</div>
+
+## Networking
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="load-balancers" size="1.5rem" /></div><div class="icon-card-label">load-balancers</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="application-gateways" size="1.5rem" /></div><div class="icon-card-label">application-gateways</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="virtual-networks" size="1.5rem" /></div><div class="icon-card-label">virtual-networks</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="dns-zones" size="1.5rem" /></div><div class="icon-card-label">dns-zones</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="front-door-and-cdn-profiles" size="1.5rem" /></div><div class="icon-card-label">front-door-and-cdn-profiles</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="firewalls" size="1.5rem" /></div><div class="icon-card-label">firewalls</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="expressroute-circuits" size="1.5rem" /></div><div class="icon-card-label">expressroute-circuits</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="virtual-wans" size="1.5rem" /></div><div class="icon-card-label">virtual-wans</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="traffic-manager-profiles" size="1.5rem" /></div><div class="icon-card-label">traffic-manager-profiles</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="nat" size="1.5rem" /></div><div class="icon-card-label">nat</div></div>
+</div>
+
+## Data &amp; Storage
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="storage-accounts" size="1.5rem" /></div><div class="icon-card-label">storage-accounts</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="azure-cosmos-db" size="1.5rem" /></div><div class="icon-card-label">azure-cosmos-db</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="sql-database" size="1.5rem" /></div><div class="icon-card-label">sql-database</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cache-redis" size="1.5rem" /></div><div class="icon-card-label">cache-redis</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="azure-database-postgresql-server" size="1.5rem" /></div><div class="icon-card-label">azure-database-postgresql-server</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="azure-database-mysql-server" size="1.5rem" /></div><div class="icon-card-label">azure-database-mysql-server</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="azure-synapse-analytics" size="1.5rem" /></div><div class="icon-card-label">azure-synapse-analytics</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="data-factories" size="1.5rem" /></div><div class="icon-card-label">data-factories</div></div>
+</div>
+
+## Security &amp; Identity
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="key-vaults" size="1.5rem" /></div><div class="icon-card-label">key-vaults</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="microsoft-defender-for-cloud" size="1.5rem" /></div><div class="icon-card-label">microsoft-defender-for-cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="azure-sentinel" size="1.5rem" /></div><div class="icon-card-label">azure-sentinel</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="application-security-groups" size="1.5rem" /></div><div class="icon-card-label">application-security-groups</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="entra-id-protection" size="1.5rem" /></div><div class="icon-card-label">entra-id-protection</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ddos-protection-plans" size="1.5rem" /></div><div class="icon-card-label">ddos-protection-plans</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="conditional-access" size="1.5rem" /></div><div class="icon-card-label">conditional-access</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="web-application-firewall-policieswaf" size="1.5rem" /></div><div class="icon-card-label">web-application-firewall-policieswaf</div></div>
+</div>
+
+## AI &amp; ML
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="azure-openai" size="1.5rem" /></div><div class="icon-card-label">azure-openai</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="machine-learning" size="1.5rem" /></div><div class="icon-card-label">machine-learning</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cognitive-services" size="1.5rem" /></div><div class="icon-card-label">cognitive-services</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bot-services" size="1.5rem" /></div><div class="icon-card-label">bot-services</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ai-studio" size="1.5rem" /></div><div class="icon-card-label">ai-studio</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="computer-vision" size="1.5rem" /></div><div class="icon-card-label">computer-vision</div></div>
+</div>
+
+## Management
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="monitor" size="1.5rem" /></div><div class="icon-card-label">monitor</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="log-analytics-workspaces" size="1.5rem" /></div><div class="icon-card-label">log-analytics-workspaces</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="application-insights" size="1.5rem" /></div><div class="icon-card-label">application-insights</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="automation-accounts" size="1.5rem" /></div><div class="icon-card-label">automation-accounts</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="policy" size="1.5rem" /></div><div class="icon-card-label">policy</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="advisor" size="1.5rem" /></div><div class="icon-card-label">advisor</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cost-management" size="1.5rem" /></div><div class="icon-card-label">cost-management</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="management-groups" size="1.5rem" /></div><div class="icon-card-label">management-groups</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 606 Azure Architecture Icons, visit the [Microsoft Azure Architecture Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/) page.

--- a/docs/carbon.mdx
+++ b/docs/carbon.mdx
@@ -1,0 +1,88 @@
+---
+title: Carbon Icons
+description: Curated reference for Carbon Icons — 2,582 enterprise-grade icons from IBM's design language available via the Icon component.
+sidebar:
+  label: Carbon
+  order: 7
+---
+
+import Icon from '@f5xc-salesdemos/icons-carbon/Icon.astro';
+
+[Carbon Icons](https://icon-sets.iconify.design/carbon/) provides 2,582 clean, outlined icons from IBM's enterprise design language. Use the `Icon` component from `@f5xc-salesdemos/icons-carbon` to render any icon by name.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-carbon/Icon.astro';
+---
+
+<Icon name="cloud" />
+<Icon name="security" size="2rem" />
+<Icon name="network-3" size="1.5rem" label="Network" />
+```
+
+Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
+
+## General
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="application" size="1.5rem" /></div><div class="icon-card-label">application</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="dashboard" size="1.5rem" /></div><div class="icon-card-label">dashboard</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="settings" size="1.5rem" /></div><div class="icon-card-label">settings</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="user" size="1.5rem" /></div><div class="icon-card-label">user</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="document" size="1.5rem" /></div><div class="icon-card-label">document</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="search" size="1.5rem" /></div><div class="icon-card-label">search</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="notification" size="1.5rem" /></div><div class="icon-card-label">notification</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="earth" size="1.5rem" /></div><div class="icon-card-label">earth</div></div>
+</div>
+
+## Networking
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="network-3" size="1.5rem" /></div><div class="icon-card-label">network-3</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="connection-signal" size="1.5rem" /></div><div class="icon-card-label">connection-signal</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="connection-two-way" size="1.5rem" /></div><div class="icon-card-label">connection-two-way</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="content-delivery-network" size="1.5rem" /></div><div class="icon-card-label">content-delivery-network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="api" size="1.5rem" /></div><div class="icon-card-label">api</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="globe" size="1.5rem" /></div><div class="icon-card-label">globe</div></div>
+</div>
+
+## Cloud
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-monitoring" size="1.5rem" /></div><div class="icon-card-label">cloud-monitoring</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-app" size="1.5rem" /></div><div class="icon-card-label">cloud-app</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-logging" size="1.5rem" /></div><div class="icon-card-label">cloud-logging</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-satellite" size="1.5rem" /></div><div class="icon-card-label">cloud-satellite</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-download" size="1.5rem" /></div><div class="icon-card-label">cloud-download</div></div>
+</div>
+
+## Data &amp; Analytics
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="data-base" size="1.5rem" /></div><div class="icon-card-label">data-base</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chart-bar" size="1.5rem" /></div><div class="icon-card-label">chart-bar</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="analytics" size="1.5rem" /></div><div class="icon-card-label">analytics</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chart-network" size="1.5rem" /></div><div class="icon-card-label">chart-network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="filter" size="1.5rem" /></div><div class="icon-card-label">filter</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="folder" size="1.5rem" /></div><div class="icon-card-label">folder</div></div>
+</div>
+
+## Interface
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="terminal" size="1.5rem" /></div><div class="icon-card-label">terminal</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="code" size="1.5rem" /></div><div class="icon-card-label">code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="security" size="1.5rem" /></div><div class="icon-card-label">security</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="warning" size="1.5rem" /></div><div class="icon-card-label">warning</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="checkmark" size="1.5rem" /></div><div class="icon-card-label">checkmark</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="email" size="1.5rem" /></div><div class="icon-card-label">email</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="download" size="1.5rem" /></div><div class="icon-card-label">download</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="upload" size="1.5rem" /></div><div class="icon-card-label">upload</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 2,582 Carbon Icons, visit the [Iconify Carbon explorer](https://icon-sets.iconify.design/carbon/).

--- a/docs/cloud-icons.mdx
+++ b/docs/cloud-icons.mdx
@@ -1,16 +1,20 @@
 ---
-title: Cloud Architecture Icons
-description: AWS, Azure, and GCP color service icons for cloud infrastructure diagrams and documentation.
+title: Cloud Architecture Icons Overview
+description: Overview of AWS, Azure, and GCP color service icon packs — shared usage patterns and links to individual pack pages.
 sidebar:
-  label: Cloud Icons
-  order: 8
+  label: Cloud Overview
+  order: 17
 ---
 
-import AwsIcon from '@f5xc-salesdemos/icons-aws/Icon.astro';
-import AzureIcon from '@f5xc-salesdemos/icons-azure/Icon.astro';
-import GcpIcon from '@f5xc-salesdemos/icons-gcp/Icon.astro';
-
 Three icon packs provide color service icons for documenting cloud infrastructure. Unlike monochrome icon packs, these preserve original vendor colors for architecture diagrams.
+
+## Available Packs
+
+| Pack | Icons | Default Size | Page |
+|------|-------|-------------|------|
+| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
+| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
+| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
 
 ## Usage
 
@@ -26,130 +30,10 @@ import GcpIcon from '@f5xc-salesdemos/icons-gcp/Icon.astro';
 <GcpIcon name="cloud-storage" />
 ```
 
-## AWS Architecture Icons
-
-885 color icons from [AWS Icons for Architecture Diagrams](https://aws.amazon.com/architecture/icons/). Default 48x48 with per-icon size overrides.
-
-### Compute
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="ec2" size="1.5rem" /></div><div class="icon-card-label">ec2</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="lambda" size="1.5rem" /></div><div class="icon-card-label">lambda</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="elastic-container-service" size="1.5rem" /></div><div class="icon-card-label">elastic-container-service</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="elastic-kubernetes-service" size="1.5rem" /></div><div class="icon-card-label">elastic-kubernetes-service</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="fargate" size="1.5rem" /></div><div class="icon-card-label">fargate</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="ec2-auto-scaling" size="1.5rem" /></div><div class="icon-card-label">ec2-auto-scaling</div></div>
-</div>
-
-### Networking
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="vpc" size="1.5rem" /></div><div class="icon-card-label">vpc</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="cloudfront" size="1.5rem" /></div><div class="icon-card-label">cloudfront</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="route-53" size="1.5rem" /></div><div class="icon-card-label">route-53</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="elastic-load-balancing" size="1.5rem" /></div><div class="icon-card-label">elastic-load-balancing</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="api-gateway" size="1.5rem" /></div><div class="icon-card-label">api-gateway</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="app-mesh" size="1.5rem" /></div><div class="icon-card-label">app-mesh</div></div>
-</div>
-
-### Storage and Database
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="simple-storage-service" size="1.5rem" /></div><div class="icon-card-label">simple-storage-service</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="dynamodb" size="1.5rem" /></div><div class="icon-card-label">dynamodb</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="aurora" size="1.5rem" /></div><div class="icon-card-label">aurora</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="elasticache" size="1.5rem" /></div><div class="icon-card-label">elasticache</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="redshift" size="1.5rem" /></div><div class="icon-card-label">redshift</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="elastic-block-store" size="1.5rem" /></div><div class="icon-card-label">elastic-block-store</div></div>
-</div>
-
-### Security
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="waf" size="1.5rem" /></div><div class="icon-card-label">waf</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="cognito" size="1.5rem" /></div><div class="icon-card-label">cognito</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="iam-identity-center" size="1.5rem" /></div><div class="icon-card-label">iam-identity-center</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="certificate-manager" size="1.5rem" /></div><div class="icon-card-label">certificate-manager</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AwsIcon name="secrets-manager" size="1.5rem" /></div><div class="icon-card-label">secrets-manager</div></div>
-</div>
-
-## Azure Architecture Icons
-
-606 color icons from [Microsoft Azure Architecture Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/). Default 18x18 with gradient fills.
-
-### Compute
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="virtual-machine" size="1.5rem" /></div><div class="icon-card-label">virtual-machine</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="function-apps" size="1.5rem" /></div><div class="icon-card-label">function-apps</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="kubernetes-services" size="1.5rem" /></div><div class="icon-card-label">kubernetes-services</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="app-services" size="1.5rem" /></div><div class="icon-card-label">app-services</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="container-instances" size="1.5rem" /></div><div class="icon-card-label">container-instances</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="container-registries" size="1.5rem" /></div><div class="icon-card-label">container-registries</div></div>
-</div>
-
-### Networking
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="load-balancers" size="1.5rem" /></div><div class="icon-card-label">load-balancers</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="application-gateways" size="1.5rem" /></div><div class="icon-card-label">application-gateways</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="virtual-networks" size="1.5rem" /></div><div class="icon-card-label">virtual-networks</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="dns-zones" size="1.5rem" /></div><div class="icon-card-label">dns-zones</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="front-door-and-cdn-profiles" size="1.5rem" /></div><div class="icon-card-label">front-door-and-cdn-profiles</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="firewalls" size="1.5rem" /></div><div class="icon-card-label">firewalls</div></div>
-</div>
-
-### Data and Storage
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="storage-accounts" size="1.5rem" /></div><div class="icon-card-label">storage-accounts</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="azure-cosmos-db" size="1.5rem" /></div><div class="icon-card-label">azure-cosmos-db</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="cache-redis" size="1.5rem" /></div><div class="icon-card-label">cache-redis</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="azure-database-mysql-server" size="1.5rem" /></div><div class="icon-card-label">azure-database-mysql-server</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="azure-database-postgresql-server" size="1.5rem" /></div><div class="icon-card-label">azure-database-postgresql-server</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><AzureIcon name="key-vaults" size="1.5rem" /></div><div class="icon-card-label">key-vaults</div></div>
-</div>
-
-## GCP Architecture Icons
-
-216 color icons from [Google Cloud Architecture Icons](https://cloud.google.com/icons). Default 24x24 with inline fills.
-
-### Compute
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="compute-engine" size="1.5rem" /></div><div class="icon-card-label">compute-engine</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-run" size="1.5rem" /></div><div class="icon-card-label">cloud-run</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-functions" size="1.5rem" /></div><div class="icon-card-label">cloud-functions</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="google-kubernetes-engine" size="1.5rem" /></div><div class="icon-card-label">google-kubernetes-engine</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="app-engine" size="1.5rem" /></div><div class="icon-card-label">app-engine</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="anthos" size="1.5rem" /></div><div class="icon-card-label">anthos</div></div>
-</div>
-
-### Networking
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-load-balancing" size="1.5rem" /></div><div class="icon-card-label">cloud-load-balancing</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-cdn" size="1.5rem" /></div><div class="icon-card-label">cloud-cdn</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-dns" size="1.5rem" /></div><div class="icon-card-label">cloud-dns</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-armor" size="1.5rem" /></div><div class="icon-card-label">cloud-armor</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="virtual-private-cloud" size="1.5rem" /></div><div class="icon-card-label">virtual-private-cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-nat" size="1.5rem" /></div><div class="icon-card-label">cloud-nat</div></div>
-</div>
-
-### Data and Storage
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-storage" size="1.5rem" /></div><div class="icon-card-label">cloud-storage</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="bigquery" size="1.5rem" /></div><div class="icon-card-label">bigquery</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-spanner" size="1.5rem" /></div><div class="icon-card-label">cloud-spanner</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="cloud-sql" size="1.5rem" /></div><div class="icon-card-label">cloud-sql</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="bigtable" size="1.5rem" /></div><div class="icon-card-label">bigtable</div></div>
-  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><GcpIcon name="pubsub" size="1.5rem" /></div><div class="icon-card-label">pubsub</div></div>
-</div>
-
 ## Color Rendering
 
 These icon packs use original vendor colors (not `currentColor`). The `no-invert` class on icon cards preserves colors in dark mode. When using these icons outside of the grid layout, no special handling is needed — colors are embedded in the SVG markup.
+
+See each pack's dedicated page for curated icon grids organized by service category.
 
 Browse full icon sets: [AWS Icons](https://aws.amazon.com/architecture/icons/) | [Azure Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/) | [GCP Icons](https://cloud.google.com/icons)

--- a/docs/f5xc.mdx
+++ b/docs/f5xc.mdx
@@ -3,7 +3,7 @@ title: F5 XC
 description: Visual reference for all 30 F5 Distributed Cloud (XC) service icons from @f5xc-salesdemos/icons-f5xc.
 sidebar:
   label: F5 XC
-  order: 8
+  order: 13
 ---
 
 import Icon from '@f5xc-salesdemos/icons-f5xc/Icon.astro';

--- a/docs/gcp.mdx
+++ b/docs/gcp.mdx
@@ -1,0 +1,107 @@
+---
+title: GCP Architecture Icons
+description: Curated reference for GCP Architecture Icons — 216 color service icons for cloud infrastructure diagrams and documentation.
+sidebar:
+  label: GCP
+  order: 16
+---
+
+import Icon from '@f5xc-salesdemos/icons-gcp/Icon.astro';
+
+[GCP Architecture Icons](https://cloud.google.com/icons) provides 216 color service icons for documenting Google Cloud infrastructure. Use the `Icon` component from `@f5xc-salesdemos/icons-gcp` to render any icon by name. Default size is 24x24 with inline fills.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-gcp/Icon.astro';
+---
+
+<Icon name="compute-engine" />
+<Icon name="cloud-run" size="2rem" />
+<Icon name="cloud-storage" size="1.5rem" label="Cloud Storage" />
+```
+
+These icons use original vendor colors (not `currentColor`). Colors are embedded in the SVG markup and preserved in both light and dark mode.
+
+## Compute
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="compute-engine" size="1.5rem" /></div><div class="icon-card-label">compute-engine</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-run" size="1.5rem" /></div><div class="icon-card-label">cloud-run</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-functions" size="1.5rem" /></div><div class="icon-card-label">cloud-functions</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="google-kubernetes-engine" size="1.5rem" /></div><div class="icon-card-label">google-kubernetes-engine</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="app-engine" size="1.5rem" /></div><div class="icon-card-label">app-engine</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="anthos" size="1.5rem" /></div><div class="icon-card-label">anthos</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="batch" size="1.5rem" /></div><div class="icon-card-label">batch</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-gpu" size="1.5rem" /></div><div class="icon-card-label">cloud-gpu</div></div>
+</div>
+
+## Networking
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-load-balancing" size="1.5rem" /></div><div class="icon-card-label">cloud-load-balancing</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-cdn" size="1.5rem" /></div><div class="icon-card-label">cloud-cdn</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-dns" size="1.5rem" /></div><div class="icon-card-label">cloud-dns</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-armor" size="1.5rem" /></div><div class="icon-card-label">cloud-armor</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="virtual-private-cloud" size="1.5rem" /></div><div class="icon-card-label">virtual-private-cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-nat" size="1.5rem" /></div><div class="icon-card-label">cloud-nat</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-router" size="1.5rem" /></div><div class="icon-card-label">cloud-router</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-vpn" size="1.5rem" /></div><div class="icon-card-label">cloud-vpn</div></div>
+</div>
+
+## Data &amp; Storage
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-storage" size="1.5rem" /></div><div class="icon-card-label">cloud-storage</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bigquery" size="1.5rem" /></div><div class="icon-card-label">bigquery</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-spanner" size="1.5rem" /></div><div class="icon-card-label">cloud-spanner</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-sql" size="1.5rem" /></div><div class="icon-card-label">cloud-sql</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bigtable" size="1.5rem" /></div><div class="icon-card-label">bigtable</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="pubsub" size="1.5rem" /></div><div class="icon-card-label">pubsub</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="dataflow" size="1.5rem" /></div><div class="icon-card-label">dataflow</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="filestore" size="1.5rem" /></div><div class="icon-card-label">filestore</div></div>
+</div>
+
+## Security
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="security-command-center" size="1.5rem" /></div><div class="icon-card-label">security-command-center</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="identity-and-access-management" size="1.5rem" /></div><div class="icon-card-label">identity-and-access-management</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="key-management-service" size="1.5rem" /></div><div class="icon-card-label">key-management-service</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="secret-manager" size="1.5rem" /></div><div class="icon-card-label">secret-manager</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="binary-authorization" size="1.5rem" /></div><div class="icon-card-label">binary-authorization</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-ids" size="1.5rem" /></div><div class="icon-card-label">cloud-ids</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="web-security-scanner" size="1.5rem" /></div><div class="icon-card-label">web-security-scanner</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="assured-workloads" size="1.5rem" /></div><div class="icon-card-label">assured-workloads</div></div>
+</div>
+
+## AI &amp; ML
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="vertexai" size="1.5rem" /></div><div class="icon-card-label">vertexai</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ai-platform" size="1.5rem" /></div><div class="icon-card-label">ai-platform</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="automl" size="1.5rem" /></div><div class="icon-card-label">automl</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-natural-language-api" size="1.5rem" /></div><div class="icon-card-label">cloud-natural-language-api</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-vision-api" size="1.5rem" /></div><div class="icon-card-label">cloud-vision-api</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="speech-to-text" size="1.5rem" /></div><div class="icon-card-label">speech-to-text</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="dialogflow" size="1.5rem" /></div><div class="icon-card-label">dialogflow</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="document-ai" size="1.5rem" /></div><div class="icon-card-label">document-ai</div></div>
+</div>
+
+## Management
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-monitoring" size="1.5rem" /></div><div class="icon-card-label">cloud-monitoring</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-logging" size="1.5rem" /></div><div class="icon-card-label">cloud-logging</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-deployment-manager" size="1.5rem" /></div><div class="icon-card-label">cloud-deployment-manager</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-build" size="1.5rem" /></div><div class="icon-card-label">cloud-build</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud-shell" size="1.5rem" /></div><div class="icon-card-label">cloud-shell</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="error-reporting" size="1.5rem" /></div><div class="icon-card-label">error-reporting</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="trace" size="1.5rem" /></div><div class="icon-card-label">trace</div></div>
+  <div class="icon-card"><div class="icon-card-image no-invert" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="profiler" size="1.5rem" /></div><div class="icon-card-label">profiler</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 216 GCP Architecture Icons, visit the [Google Cloud Architecture Icons](https://cloud.google.com/icons) page.

--- a/docs/hashicorp-flight.mdx
+++ b/docs/hashicorp-flight.mdx
@@ -3,7 +3,7 @@ title: HashiCorp Flight Icons
 description: Visual reference for all 672 HashiCorp Flight icons from @f5xc-salesdemos/icons-hashicorp-flight.
 sidebar:
   label: HashiCorp Flight
-  order: 7
+  order: 12
 ---
 
 import Icon from '@f5xc-salesdemos/icons-hashicorp-flight/Icon.astro';

--- a/docs/iconify-packs.mdx
+++ b/docs/iconify-packs.mdx
@@ -1,26 +1,21 @@
 ---
-title: Iconify
-description: Curated reference for Material Design, Carbon, Phosphor, and Tabler icon packs available via Icon components.
+title: Iconify Packs Overview
+description: Overview of Material Design, Carbon, Phosphor, and Tabler icon packs — comparison, shared usage patterns, and links to individual pack pages.
 sidebar:
-  label: Iconify
-  order: 6
+  label: Iconify Overview
+  order: 10
 ---
-
-import MdiIcon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
-import CarbonIcon from '@f5xc-salesdemos/icons-carbon/Icon.astro';
-import PhIcon from '@f5xc-salesdemos/icons-phosphor/Icon.astro';
-import TablerIcon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
 
 Multiple Iconify icon packs are available as npm packages with Astro `Icon` components. Each pack has its own import and uses the same `name`-based API.
 
 ## Pack Comparison
 
-| Pack | Prefix | Icons | Style | Best For |
-|------|--------|-------|-------|----------|
-| Material Design | `mdi` | 7,000+ | Filled + outlined | General-purpose, broadest coverage |
-| Carbon | `carbon` | ~1,500 | Outlined | Enterprise/IBM design, clean lines |
-| Phosphor | `ph` | ~1,200 | Multiple weights | Flexible weight options (thin to fill) |
-| Tabler | `tabler` | ~4,500 | Stroke-based | Crisp line icons, consistent stroke |
+| Pack | Prefix | Icons | Style | Best For | Page |
+|------|--------|-------|-------|----------|------|
+| Material Design | `mdi` | 7,638 | Filled + outlined | General-purpose, broadest coverage | [Material Design](/mdi/) |
+| Carbon | `carbon` | 2,582 | Outlined | Enterprise/IBM design, clean lines | [Carbon](/carbon/) |
+| Phosphor | `ph` | 9,161 | Multiple weights | Flexible weight options (thin to fill) | [Phosphor](/phosphor/) |
+| Tabler | `tabler` | 6,034 | Stroke-based | Crisp line icons, consistent stroke | [Tabler](/tabler/) |
 
 ## Usage
 
@@ -42,113 +37,11 @@ import TablerIcon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
 
 Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
 
-## Material Design Icons (mdi)
+## Choosing a Pack
 
-The largest icon pack with 7,000+ icons covering virtually every use case.
+- **Broadest coverage**: Material Design Icons has the most icons (7,638) with filled and outlined variants for virtually every use case.
+- **Enterprise design**: Carbon follows IBM's design language with clean, consistent outlines suited for business applications.
+- **Weight flexibility**: Phosphor provides six weight variants (thin, light, regular, bold, fill, duotone) for fine-tuning visual weight.
+- **Consistent strokes**: Tabler uses a uniform 2px stroke width across all 6,034 icons for a cohesive look.
 
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="database" size="1.5rem" /></div><div class="icon-card-label">database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="server" size="1.5rem" /></div><div class="icon-card-label">server</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="shield-lock" size="1.5rem" /></div><div class="icon-card-label">shield-lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="fire" size="1.5rem" /></div><div class="icon-card-label">fire</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="account" size="1.5rem" /></div><div class="icon-card-label">account</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="cog" size="1.5rem" /></div><div class="icon-card-label">cog</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="chart-bar" size="1.5rem" /></div><div class="icon-card-label">chart-bar</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="network" size="1.5rem" /></div><div class="icon-card-label">network</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="key" size="1.5rem" /></div><div class="icon-card-label">key</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="web" size="1.5rem" /></div><div class="icon-card-label">web</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="api" size="1.5rem" /></div><div class="icon-card-label">api</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="dns" size="1.5rem" /></div><div class="icon-card-label">dns</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="kubernetes" size="1.5rem" /></div><div class="icon-card-label">kubernetes</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="docker" size="1.5rem" /></div><div class="icon-card-label">docker</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="terraform" size="1.5rem" /></div><div class="icon-card-label">terraform</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="console" size="1.5rem" /></div><div class="icon-card-label">console</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="memory" size="1.5rem" /></div><div class="icon-card-label">memory</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="monitor-dashboard" size="1.5rem" /></div><div class="icon-card-label">monitor-dashboard</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="robot" size="1.5rem" /></div><div class="icon-card-label">robot</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="earth" size="1.5rem" /></div><div class="icon-card-label">earth</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="lan" size="1.5rem" /></div><div class="icon-card-label">lan</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="access-point" size="1.5rem" /></div><div class="icon-card-label">access-point</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="alert" size="1.5rem" /></div><div class="icon-card-label">alert</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="check-circle" size="1.5rem" /></div><div class="icon-card-label">check-circle</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="code-tags" size="1.5rem" /></div><div class="icon-card-label">code-tags</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="file-document" size="1.5rem" /></div><div class="icon-card-label">file-document</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="github" size="1.5rem" /></div><div class="icon-card-label">github</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><MdiIcon name="lightning-bolt" size="1.5rem" /></div><div class="icon-card-label">lightning-bolt</div></div>
-</div>
-
-Browse all: [Iconify MDI explorer](https://icon-sets.iconify.design/mdi/)
-
-## Carbon Icons (carbon)
-
-IBM's enterprise design language with ~1,500 clean, outlined icons.
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="security" size="1.5rem" /></div><div class="icon-card-label">security</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="network-3" size="1.5rem" /></div><div class="icon-card-label">network-3</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="data-base" size="1.5rem" /></div><div class="icon-card-label">data-base</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="application" size="1.5rem" /></div><div class="icon-card-label">application</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="api" size="1.5rem" /></div><div class="icon-card-label">api</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="dashboard" size="1.5rem" /></div><div class="icon-card-label">dashboard</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="terminal" size="1.5rem" /></div><div class="icon-card-label">terminal</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="code" size="1.5rem" /></div><div class="icon-card-label">code</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="user" size="1.5rem" /></div><div class="icon-card-label">user</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="settings" size="1.5rem" /></div><div class="icon-card-label">settings</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="document" size="1.5rem" /></div><div class="icon-card-label">document</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="earth" size="1.5rem" /></div><div class="icon-card-label">earth</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="warning" size="1.5rem" /></div><div class="icon-card-label">warning</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><CarbonIcon name="checkmark" size="1.5rem" /></div><div class="icon-card-label">checkmark</div></div>
-</div>
-
-Browse all: [Iconify Carbon explorer](https://icon-sets.iconify.design/carbon/)
-
-## Phosphor Icons (ph)
-
-~1,200 icons with flexible weight options — thin, light, regular, bold, fill, and duotone.
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="globe" size="1.5rem" /></div><div class="icon-card-label">globe</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="database" size="1.5rem" /></div><div class="icon-card-label">database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="user" size="1.5rem" /></div><div class="icon-card-label">user</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="gear" size="1.5rem" /></div><div class="icon-card-label">gear</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="code" size="1.5rem" /></div><div class="icon-card-label">code</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="terminal-window" size="1.5rem" /></div><div class="icon-card-label">terminal-window</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="rocket" size="1.5rem" /></div><div class="icon-card-label">rocket</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="lightning" size="1.5rem" /></div><div class="icon-card-label">lightning</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="chart-bar" size="1.5rem" /></div><div class="icon-card-label">chart-bar</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="file" size="1.5rem" /></div><div class="icon-card-label">file</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="warning" size="1.5rem" /></div><div class="icon-card-label">warning</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><PhIcon name="check-circle" size="1.5rem" /></div><div class="icon-card-label">check-circle</div></div>
-</div>
-
-Browse all: [Iconify Phosphor explorer](https://icon-sets.iconify.design/ph/)
-
-## Tabler Icons (tabler)
-
-~4,500 crisp line icons with consistent 2px stroke width.
-
-<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="database" size="1.5rem" /></div><div class="icon-card-label">database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="server" size="1.5rem" /></div><div class="icon-card-label">server</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="network" size="1.5rem" /></div><div class="icon-card-label">network</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="key" size="1.5rem" /></div><div class="icon-card-label">key</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="code" size="1.5rem" /></div><div class="icon-card-label">code</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="terminal" size="1.5rem" /></div><div class="icon-card-label">terminal</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="world" size="1.5rem" /></div><div class="icon-card-label">world</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="user" size="1.5rem" /></div><div class="icon-card-label">user</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="settings" size="1.5rem" /></div><div class="icon-card-label">settings</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="rocket" size="1.5rem" /></div><div class="icon-card-label">rocket</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="bolt" size="1.5rem" /></div><div class="icon-card-label">bolt</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><TablerIcon name="chart-bar" size="1.5rem" /></div><div class="icon-card-label">chart-bar</div></div>
-</div>
-
-Browse all: [Iconify Tabler explorer](https://icon-sets.iconify.design/tabler/)
+See each pack's dedicated page for curated icon grids and browsing links.

--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -21,16 +21,16 @@ The documentation theme provides access to thousands of icons from multiple pack
 | Starlight Built-in | ~200 | `<Icon name="star" />` | [Starlight Built-in](/starlight/) |
 | F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
 | Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,000+ | `<Icon name="database" />` | [Iconify Packs](/iconify-packs/) |
-| Carbon | ~1,500 | `<Icon name="cloud" />` | [Iconify Packs](/iconify-packs/) |
-| Phosphor | ~1,200 | `<Icon name="globe" />` | [Iconify Packs](/iconify-packs/) |
-| Tabler | ~4,500 | `<Icon name="shield" />` | [Iconify Packs](/iconify-packs/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
 | F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
 | Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
 | HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [Cloud Icons](/cloud-icons/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Cloud Icons](/cloud-icons/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [Cloud Icons](/cloud-icons/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
 
 ## Rendering Method
 
@@ -86,10 +86,10 @@ F5 XC service icons use CSS custom properties that automatically adapt to light 
 | General UI (arrows, close, search) | Starlight Built-in | Zero config, always available |
 | F5 product diagrams | F5 Brand | Domain-specific networking/security art |
 | Modern stroke icons | Lucide | Clean, consistent 1,600+ icons |
-| Filled/outlined icons at scale | Material Design (mdi) | Largest set with 7,000+ icons |
-| IBM design language | Carbon | Enterprise-grade icons |
-| Flexible weight options | Phosphor | Thin/light/regular/bold/fill/duotone |
-| Crisp line icons | Tabler | 4,500+ with consistent stroke |
+| Filled/outlined icons at scale | Material Design (mdi) | Largest set with 7,638 icons |
+| IBM design language | Carbon | 2,582 enterprise-grade icons |
+| Flexible weight options | Phosphor | 9,161 icons with six weight variants |
+| Crisp line icons | Tabler | 6,034 icons with consistent 2px stroke |
 | F5 XC service diagrams | F5 XC Services | 30 Distributed Cloud service icons |
 | Brand/company logos | Simple Icons | 3,200+ brand icons for vendors and services |
 | Cloud/infra vendor logos | HashiCorp Flight | AWS, GCP, Azure, K8s vendor icons |

--- a/docs/mdi.mdx
+++ b/docs/mdi.mdx
@@ -1,0 +1,90 @@
+---
+title: Material Design Icons
+description: Curated reference for Material Design Icons — 7,638 filled and outlined icons available via the Icon component.
+sidebar:
+  label: Material Design
+  order: 6
+---
+
+import Icon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
+
+[Material Design Icons](https://icon-sets.iconify.design/mdi/) provides 7,638 icons with filled and outlined variants covering virtually every use case. Use the `Icon` component from `@f5xc-salesdemos/icons-mdi` to render any icon by name.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-mdi/Icon.astro';
+---
+
+<Icon name="database" />
+<Icon name="shield-lock" size="2rem" />
+<Icon name="cloud" size="1.5rem" label="Cloud" />
+```
+
+Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
+
+## General
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="account" size="1.5rem" /></div><div class="icon-card-label">account</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cog" size="1.5rem" /></div><div class="icon-card-label">cog</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="file-document" size="1.5rem" /></div><div class="icon-card-label">file-document</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chart-bar" size="1.5rem" /></div><div class="icon-card-label">chart-bar</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="alert" size="1.5rem" /></div><div class="icon-card-label">alert</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="check-circle" size="1.5rem" /></div><div class="icon-card-label">check-circle</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="robot" size="1.5rem" /></div><div class="icon-card-label">robot</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="monitor-dashboard" size="1.5rem" /></div><div class="icon-card-label">monitor-dashboard</div></div>
+</div>
+
+## Networking
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="network" size="1.5rem" /></div><div class="icon-card-label">network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lan" size="1.5rem" /></div><div class="icon-card-label">lan</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="dns" size="1.5rem" /></div><div class="icon-card-label">dns</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="web" size="1.5rem" /></div><div class="icon-card-label">web</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="api" size="1.5rem" /></div><div class="icon-card-label">api</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="earth" size="1.5rem" /></div><div class="icon-card-label">earth</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="access-point" size="1.5rem" /></div><div class="icon-card-label">access-point</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="access-point-network" size="1.5rem" /></div><div class="icon-card-label">access-point-network</div></div>
+</div>
+
+## Security
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="shield-lock" size="1.5rem" /></div><div class="icon-card-label">shield-lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="key" size="1.5rem" /></div><div class="icon-card-label">key</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="fire" size="1.5rem" /></div><div class="icon-card-label">fire</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="eye" size="1.5rem" /></div><div class="icon-card-label">eye</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="incognito" size="1.5rem" /></div><div class="icon-card-label">incognito</div></div>
+</div>
+
+## Cloud &amp; DevOps
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="server" size="1.5rem" /></div><div class="icon-card-label">server</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="database" size="1.5rem" /></div><div class="icon-card-label">database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="kubernetes" size="1.5rem" /></div><div class="icon-card-label">kubernetes</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="docker" size="1.5rem" /></div><div class="icon-card-label">docker</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="terraform" size="1.5rem" /></div><div class="icon-card-label">terraform</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="console" size="1.5rem" /></div><div class="icon-card-label">console</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="memory" size="1.5rem" /></div><div class="icon-card-label">memory</div></div>
+</div>
+
+## Data &amp; Analytics
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="code-tags" size="1.5rem" /></div><div class="icon-card-label">code-tags</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="github" size="1.5rem" /></div><div class="icon-card-label">github</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lightning-bolt" size="1.5rem" /></div><div class="icon-card-label">lightning-bolt</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="source-branch" size="1.5rem" /></div><div class="icon-card-label">source-branch</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="clipboard-text" size="1.5rem" /></div><div class="icon-card-label">clipboard-text</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="magnify" size="1.5rem" /></div><div class="icon-card-label">magnify</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 7,638 Material Design Icons, visit the [Iconify MDI explorer](https://icon-sets.iconify.design/mdi/).

--- a/docs/phosphor.mdx
+++ b/docs/phosphor.mdx
@@ -1,0 +1,91 @@
+---
+title: Phosphor Icons
+description: Curated reference for Phosphor Icons — 9,161 icons with flexible weight variants available via the Icon component.
+sidebar:
+  label: Phosphor
+  order: 8
+---
+
+import Icon from '@f5xc-salesdemos/icons-phosphor/Icon.astro';
+
+[Phosphor Icons](https://icon-sets.iconify.design/ph/) provides 9,161 icons with flexible weight options — regular, bold, duotone, fill, light, and thin. Use the `Icon` component from `@f5xc-salesdemos/icons-phosphor` to render any icon by name.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-phosphor/Icon.astro';
+---
+
+<Icon name="globe" />
+<Icon name="shield" size="2rem" />
+<Icon name="cloud" size="1.5rem" label="Cloud" />
+```
+
+Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
+
+:::note[Weight Variants]
+Phosphor icons come in six weights. The regular weight uses the base name (e.g. `globe`). Other weights append a suffix: `globe-bold`, `globe-duotone`, `globe-fill`, `globe-light`, `globe-thin`. The examples below show the regular weight.
+:::
+
+## General
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="globe" size="1.5rem" /></div><div class="icon-card-label">globe</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="database" size="1.5rem" /></div><div class="icon-card-label">database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="user" size="1.5rem" /></div><div class="icon-card-label">user</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="gear" size="1.5rem" /></div><div class="icon-card-label">gear</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="code" size="1.5rem" /></div><div class="icon-card-label">code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="terminal-window" size="1.5rem" /></div><div class="icon-card-label">terminal-window</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="rocket" size="1.5rem" /></div><div class="icon-card-label">rocket</div></div>
+</div>
+
+## Arrows &amp; Navigation
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="arrow-up" size="1.5rem" /></div><div class="icon-card-label">arrow-up</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="arrow-down" size="1.5rem" /></div><div class="icon-card-label">arrow-down</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="arrow-left" size="1.5rem" /></div><div class="icon-card-label">arrow-left</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="arrow-right" size="1.5rem" /></div><div class="icon-card-label">arrow-right</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="compass" size="1.5rem" /></div><div class="icon-card-label">compass</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="map-pin" size="1.5rem" /></div><div class="icon-card-label">map-pin</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="house" size="1.5rem" /></div><div class="icon-card-label">house</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="magnifying-glass" size="1.5rem" /></div><div class="icon-card-label">magnifying-glass</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="sign-in" size="1.5rem" /></div><div class="icon-card-label">sign-in</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="sign-out" size="1.5rem" /></div><div class="icon-card-label">sign-out</div></div>
+</div>
+
+## Objects
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="file" size="1.5rem" /></div><div class="icon-card-label">file</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="folder" size="1.5rem" /></div><div class="icon-card-label">folder</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="key" size="1.5rem" /></div><div class="icon-card-label">key</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cpu" size="1.5rem" /></div><div class="icon-card-label">cpu</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="hard-drive" size="1.5rem" /></div><div class="icon-card-label">hard-drive</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="desktop" size="1.5rem" /></div><div class="icon-card-label">desktop</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="browser" size="1.5rem" /></div><div class="icon-card-label">browser</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="plug" size="1.5rem" /></div><div class="icon-card-label">plug</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="wrench" size="1.5rem" /></div><div class="icon-card-label">wrench</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="clipboard" size="1.5rem" /></div><div class="icon-card-label">clipboard</div></div>
+</div>
+
+## Communication
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="envelope" size="1.5rem" /></div><div class="icon-card-label">envelope</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chat-text" size="1.5rem" /></div><div class="icon-card-label">chat-text</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="phone" size="1.5rem" /></div><div class="icon-card-label">phone</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bell" size="1.5rem" /></div><div class="icon-card-label">bell</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="broadcast" size="1.5rem" /></div><div class="icon-card-label">broadcast</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="wifi-high" size="1.5rem" /></div><div class="icon-card-label">wifi-high</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="share-network" size="1.5rem" /></div><div class="icon-card-label">share-network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="link" size="1.5rem" /></div><div class="icon-card-label">link</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 9,161 Phosphor Icons (across all weight variants), visit the [Iconify Phosphor explorer](https://icon-sets.iconify.design/ph/).

--- a/docs/simple-icons.mdx
+++ b/docs/simple-icons.mdx
@@ -3,7 +3,7 @@ title: Simple Icons
 description: 3,200+ brand icons for popular companies, services, and technologies from the Simple Icons project.
 sidebar:
   label: Simple Icons
-  order: 7
+  order: 11
 ---
 
 import SimpleIcon from '@f5xc-salesdemos/icons-simple-icons/Icon.astro';

--- a/docs/tabler.mdx
+++ b/docs/tabler.mdx
@@ -1,0 +1,87 @@
+---
+title: Tabler Icons
+description: Curated reference for Tabler Icons — 6,034 crisp line icons with consistent stroke width available via the Icon component.
+sidebar:
+  label: Tabler
+  order: 9
+---
+
+import Icon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
+
+[Tabler Icons](https://icon-sets.iconify.design/tabler/) provides 6,034 crisp line icons with a consistent 2px stroke width. Use the `Icon` component from `@f5xc-salesdemos/icons-tabler` to render any icon by name.
+
+## Usage
+
+```astro
+---
+import Icon from '@f5xc-salesdemos/icons-tabler/Icon.astro';
+---
+
+<Icon name="shield" />
+<Icon name="cloud" size="2rem" />
+<Icon name="server" size="1.5rem" label="Server" />
+```
+
+Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
+
+## General
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="shield" size="1.5rem" /></div><div class="icon-card-label">shield</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="cloud" size="1.5rem" /></div><div class="icon-card-label">cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="database" size="1.5rem" /></div><div class="icon-card-label">database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="server" size="1.5rem" /></div><div class="icon-card-label">server</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lock" size="1.5rem" /></div><div class="icon-card-label">lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="key" size="1.5rem" /></div><div class="icon-card-label">key</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="user" size="1.5rem" /></div><div class="icon-card-label">user</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="settings" size="1.5rem" /></div><div class="icon-card-label">settings</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="home" size="1.5rem" /></div><div class="icon-card-label">home</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="search" size="1.5rem" /></div><div class="icon-card-label">search</div></div>
+</div>
+
+## Interface
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="layout-dashboard" size="1.5rem" /></div><div class="icon-card-label">layout-dashboard</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="filter" size="1.5rem" /></div><div class="icon-card-label">filter</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="sort-ascending" size="1.5rem" /></div><div class="icon-card-label">sort-ascending</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="eye" size="1.5rem" /></div><div class="icon-card-label">eye</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="clipboard" size="1.5rem" /></div><div class="icon-card-label">clipboard</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bookmark" size="1.5rem" /></div><div class="icon-card-label">bookmark</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tag" size="1.5rem" /></div><div class="icon-card-label">tag</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="alert-circle" size="1.5rem" /></div><div class="icon-card-label">alert-circle</div></div>
+</div>
+
+## Networking
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="network" size="1.5rem" /></div><div class="icon-card-label">network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="world" size="1.5rem" /></div><div class="icon-card-label">world</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="antenna" size="1.5rem" /></div><div class="icon-card-label">antenna</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="api" size="1.5rem" /></div><div class="icon-card-label">api</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="wifi" size="1.5rem" /></div><div class="icon-card-label">wifi</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="router" size="1.5rem" /></div><div class="icon-card-label">router</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="sitemap" size="1.5rem" /></div><div class="icon-card-label">sitemap</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="topology-star" size="1.5rem" /></div><div class="icon-card-label">topology-star</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="webhook" size="1.5rem" /></div><div class="icon-card-label">webhook</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="access-point" size="1.5rem" /></div><div class="icon-card-label">access-point</div></div>
+</div>
+
+## Development
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="code" size="1.5rem" /></div><div class="icon-card-label">code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="terminal" size="1.5rem" /></div><div class="icon-card-label">terminal</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="git-branch" size="1.5rem" /></div><div class="icon-card-label">git-branch</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="git-merge" size="1.5rem" /></div><div class="icon-card-label">git-merge</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="brand-github" size="1.5rem" /></div><div class="icon-card-label">brand-github</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bug" size="1.5rem" /></div><div class="icon-card-label">bug</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="binary" size="1.5rem" /></div><div class="icon-card-label">binary</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="rocket" size="1.5rem" /></div><div class="icon-card-label">rocket</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="bolt" size="1.5rem" /></div><div class="icon-card-label">bolt</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="chart-bar" size="1.5rem" /></div><div class="icon-card-label">chart-bar</div></div>
+</div>
+
+## Browse All Icons
+
+For the complete list of 6,034 Tabler Icons, visit the [Iconify Tabler explorer](https://icon-sets.iconify.design/tabler/).


### PR DESCRIPTION
## Summary
- Create 7 new standalone MDX pages (MDI, Carbon, Phosphor, Tabler, AWS, Azure, GCP) with categorized icon grids
- Convert `iconify-packs.mdx` and `cloud-icons.mdx` to overview pages with links to standalone pages
- Update `icons.mdx` overview table with accurate icon counts and direct links
- Update sidebar order values across all pages for logical grouping

## Test plan
- [ ] Verify all 7 new pages render correctly in the docs dev server
- [ ] Verify iconify-packs.mdx and cloud-icons.mdx overview pages link correctly
- [ ] Verify icons.mdx table links point to the correct standalone pages
- [ ] Verify sidebar order is correct (1-17, no gaps or duplicates)
- [ ] Verify monochrome icons adapt to dark mode via `currentColor`
- [ ] Verify cloud icons preserve vendor colors via `no-invert` class

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)