### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,4 +1,9 @@
 ---
+skip-path:
+  - dist
+  - build
+  - release
+  - vendor
 skip-check:
   - CKV_GHA_7
   - CKV2_GHA_1

--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -32,6 +32,10 @@
     ".prettierignore",
     ".trivyignore",
     "ruff.toml",
+    ".ruff.toml",
+    ".isort.cfg",
+    ".python-lint",
+    ".mypy.ini",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,preceeding,uncomplete,ves
+skip = *.json,*.lock,*/tools/generated/*,vendor/*
+ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve PR

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+profile = black
+force_sort_within_sections = False
+combine_as_imports = True

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -7,6 +7,7 @@
     "**/node_modules/**",
     "**/dist/**",
     "**/build/**",
+    "**/release/**",
     "**/.git/**",
     "**/vendor/**",
     "**/internal/client/**",

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+check_untyped_defs = True
+warn_return_any = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+show_error_codes = True
+warn_unused_ignores = True
+no_implicit_reexport = False

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,9 @@
 **/*.gen.ts
 **/*.gen.js
 **/*.gen.d.ts
+
+# Build and release output
+dist/
+build/
+release/
+vendor/

--- a/.python-lint
+++ b/.python-lint
@@ -1,0 +1,51 @@
+[MAIN]
+py-version = 3.11
+jobs = 0
+
+[FORMAT]
+max-line-length = 88
+indent-string = '    '
+expected-line-ending-format = LF
+
+[DESIGN]
+max-args = 7
+max-branches = 15
+max-locals = 20
+max-returns = 6
+max-statements = 60
+max-attributes = 10
+max-public-methods = 25
+min-public-methods = 0
+
+[MESSAGES CONTROL]
+disable =
+    C0114,
+    C0115,
+    C0116,
+    C0206,
+    C0301,
+    C0303,
+    C0411,
+    C0413,
+    E0401,
+    E1101,
+    R0801,
+    R0903,
+    R0917,
+    R1702,
+    W0511,
+    W0611,
+    W0612,
+    W0613,
+    W0621,
+    W0622,
+    W1514
+
+[BASIC]
+good-names = i, j, k, ex, _, id, pk, db, fn, ip, ok, df
+
+[SIMILARITIES]
+min-similarity-lines = 10
+ignore-comments = yes
+ignore-docstrings = yes
+ignore-imports = yes

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,74 @@
+extend = "pyproject.toml"
 line-length = 88
 
 [format]
 quote-style = "double"
 indent-style = "space"
+
+[lint]
+extend-select = [
+    "E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF", "PERF", "FURB",
+    "S", "TRY", "RSE", "EM", "N", "A", "Q", "COM", "RET", "ARG", "PTH",
+    "T20", "LOG", "G", "TCH", "ANN", "PT", "D", "ERA",
+    "PLC", "PLE", "PLR", "PLW",
+    "PIE", "ISC", "ICN", "PGH", "FLY", "SLF", "TD", "FIX",
+    "YTT", "DTZ", "EXE", "FA", "INT", "INP",
+]
+ignore = [
+    "E501",
+    "COM812",
+    "ISC001",
+    "D100",
+    "D104",
+    "D203",
+    "D213",
+    "ANN401",
+    "TD002",
+    "TD003",
+    "FIX002",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+    "ARG002",
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
+[lint.isort]
+split-on-trailing-comma = true
+combine-as-imports = true
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pylint]
+max-args = 7
+max-returns = 6
+max-branches = 15
+
+[lint.mccabe]
+max-complexity = 15

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,11 @@ ignore: |
   docs/specifications/
 rules:
   line-length: disable
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
   truthy:
     allowed-values: ["true", "false", "on"]
   comments:

--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,15 @@
   },
   "overrides": [
     {
+      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "formatter": {
+        "enabled": false
+      },
+      "linter": {
+        "enabled": false
+      }
+    },
+    {
       "includes": ["**/*.astro"],
       "linter": {
         "rules": {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,74 @@
+extend = "pyproject.toml"
 line-length = 88
 
 [format]
 quote-style = "double"
 indent-style = "space"
+
+[lint]
+extend-select = [
+    "E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF", "PERF", "FURB",
+    "S", "TRY", "RSE", "EM", "N", "A", "Q", "COM", "RET", "ARG", "PTH",
+    "T20", "LOG", "G", "TCH", "ANN", "PT", "D", "ERA",
+    "PLC", "PLE", "PLR", "PLW",
+    "PIE", "ISC", "ICN", "PGH", "FLY", "SLF", "TD", "FIX",
+    "YTT", "DTZ", "EXE", "FA", "INT", "INP",
+]
+ignore = [
+    "E501",
+    "COM812",
+    "ISC001",
+    "D100",
+    "D104",
+    "D203",
+    "D213",
+    "ANN401",
+    "TD002",
+    "TD003",
+    "FIX002",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+    "ARG002",
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
+[lint.isort]
+split-on-trailing-comma = true
+combine-as-imports = true
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pylint]
+max-args = 7
+max-returns = 6
+max-branches = 15
+
+[lint.mccabe]
+max-complexity = 15


### PR DESCRIPTION
Closes #256

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .yamllint.yaml
- .github/workflows/dependabot-auto-merge.yml
- biome.json
- .jscpd.json
- .checkov.yaml
- .codespellrc
- .prettierignore
- .ruff.toml
- ruff.toml
- .isort.cfg
- .python-lint
- .mypy.ini
- .claude/governance.json