### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,14 +22,22 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     commit-message:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
     groups:
+      # First-party @f5xc-salesdemos/* packages: track latest daily, all update types
+      # (auto-merged once CI is green) so internal deps never drift behind.
+      f5xc-internal:
+        patterns:
+          - "@f5xc-salesdemos/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       npm-minor-patch:
         update-types:
           - "minor"


### PR DESCRIPTION
Closes #580

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/dependabot.yml