### PR TITLE
fix: restamp stale translation sourceHash (unblocks Translation freshness)

### DIFF
--- a/docs/ar/aws.mdx
+++ b/docs/ar/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/ar/azure.mdx
+++ b/docs/ar/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/ar/brand.mdx
+++ b/docs/ar/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: علامة F5 التجارية
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/ar/carbon.mdx
+++ b/docs/ar/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/ar/cloud-icons.mdx
+++ b/docs/ar/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: نظرة عامة على السحابة
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/ar/f5xc.mdx
+++ b/docs/ar/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/ar/gcp.mdx
+++ b/docs/ar/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/ar/hashicorp-flight.mdx
+++ b/docs/ar/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/ar/iconify-packs.mdx
+++ b/docs/ar/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: نظرة عامة على Iconify
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/ar/icons.mdx
+++ b/docs/ar/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: نظرة عامة
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/ar/lucide.mdx
+++ b/docs/ar/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/ar/mdi.mdx
+++ b/docs/ar/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/ar/phosphor.mdx
+++ b/docs/ar/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/ar/simple-icons.mdx
+++ b/docs/ar/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: أيقونات Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/ar/tabler.mdx
+++ b/docs/ar/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/de/aws.mdx
+++ b/docs/de/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/de/azure.mdx
+++ b/docs/de/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/de/brand.mdx
+++ b/docs/de/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 Marke
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/de/carbon.mdx
+++ b/docs/de/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/de/cloud-icons.mdx
+++ b/docs/de/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Cloud-Übersicht
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/de/f5xc.mdx
+++ b/docs/de/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/de/gcp.mdx
+++ b/docs/de/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/de/hashicorp-flight.mdx
+++ b/docs/de/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/de/iconify-packs.mdx
+++ b/docs/de/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify Übersicht
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/de/icons.mdx
+++ b/docs/de/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Überblick
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/de/lucide.mdx
+++ b/docs/de/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/de/mdi.mdx
+++ b/docs/de/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/de/phosphor.mdx
+++ b/docs/de/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/de/simple-icons.mdx
+++ b/docs/de/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/de/tabler.mdx
+++ b/docs/de/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/es/aws.mdx
+++ b/docs/es/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/es/azure.mdx
+++ b/docs/es/azure.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/es/brand.mdx
+++ b/docs/es/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Marca F5
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/es/carbon.mdx
+++ b/docs/es/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/es/cloud-icons.mdx
+++ b/docs/es/cloud-icons.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Descripción general de la nube
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/es/f5xc.mdx
+++ b/docs/es/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/es/gcp.mdx
+++ b/docs/es/gcp.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/es/hashicorp-flight.mdx
+++ b/docs/es/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/es/iconify-packs.mdx
+++ b/docs/es/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Resumen de Iconify
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/es/icons.mdx
+++ b/docs/es/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Descripción general
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/es/lucide.mdx
+++ b/docs/es/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/es/mdi.mdx
+++ b/docs/es/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/es/phosphor.mdx
+++ b/docs/es/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/es/simple-icons.mdx
+++ b/docs/es/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/es/tabler.mdx
+++ b/docs/es/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/fr/aws.mdx
+++ b/docs/fr/aws.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/fr/azure.mdx
+++ b/docs/fr/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/fr/brand.mdx
+++ b/docs/fr/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Marque F5
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/fr/carbon.mdx
+++ b/docs/fr/carbon.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/fr/cloud-icons.mdx
+++ b/docs/fr/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Aperçu Cloud
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/fr/f5xc.mdx
+++ b/docs/fr/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/fr/gcp.mdx
+++ b/docs/fr/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/fr/hashicorp-flight.mdx
+++ b/docs/fr/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/fr/iconify-packs.mdx
+++ b/docs/fr/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Aperçu Iconify
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/fr/icons.mdx
+++ b/docs/fr/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Aperçu
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/fr/lucide.mdx
+++ b/docs/fr/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/fr/mdi.mdx
+++ b/docs/fr/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/fr/phosphor.mdx
+++ b/docs/fr/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/fr/simple-icons.mdx
+++ b/docs/fr/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/fr/tabler.mdx
+++ b/docs/fr/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/hi/aws.mdx
+++ b/docs/hi/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/hi/azure.mdx
+++ b/docs/hi/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/hi/brand.mdx
+++ b/docs/hi/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 ब्रांड
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/hi/carbon.mdx
+++ b/docs/hi/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: कार्बन
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/hi/cloud-icons.mdx
+++ b/docs/hi/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: क्लाउड अवलोकन
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/hi/f5xc.mdx
+++ b/docs/hi/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/hi/gcp.mdx
+++ b/docs/hi/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/hi/hashicorp-flight.mdx
+++ b/docs/hi/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/hi/iconify-packs.mdx
+++ b/docs/hi/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify अवलोकन
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/hi/icons.mdx
+++ b/docs/hi/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: अवलोकन
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/hi/lucide.mdx
+++ b/docs/hi/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/hi/mdi.mdx
+++ b/docs/hi/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: मटेरियल डिज़ाइन
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/hi/phosphor.mdx
+++ b/docs/hi/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/hi/simple-icons.mdx
+++ b/docs/hi/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: सिम्पल आइकन्स
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/hi/tabler.mdx
+++ b/docs/hi/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/it/aws.mdx
+++ b/docs/it/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/it/azure.mdx
+++ b/docs/it/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/it/brand.mdx
+++ b/docs/it/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Brand F5
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/it/carbon.mdx
+++ b/docs/it/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/it/cloud-icons.mdx
+++ b/docs/it/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Panoramica Cloud
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/it/f5xc.mdx
+++ b/docs/it/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/it/gcp.mdx
+++ b/docs/it/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/it/hashicorp-flight.mdx
+++ b/docs/it/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/it/iconify-packs.mdx
+++ b/docs/it/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Panoramica Iconify
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/it/icons.mdx
+++ b/docs/it/icons.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Panoramica
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/it/lucide.mdx
+++ b/docs/it/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/it/mdi.mdx
+++ b/docs/it/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/it/phosphor.mdx
+++ b/docs/it/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/it/simple-icons.mdx
+++ b/docs/it/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/it/tabler.mdx
+++ b/docs/it/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/ja/aws.mdx
+++ b/docs/ja/aws.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/ja/azure.mdx
+++ b/docs/ja/azure.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/ja/brand.mdx
+++ b/docs/ja/brand.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: F5 ブランド
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/ja/carbon.mdx
+++ b/docs/ja/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/ja/cloud-icons.mdx
+++ b/docs/ja/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: クラウド概要
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/ja/f5xc.mdx
+++ b/docs/ja/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/ja/gcp.mdx
+++ b/docs/ja/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/ja/hashicorp-flight.mdx
+++ b/docs/ja/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/ja/iconify-packs.mdx
+++ b/docs/ja/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify 概要
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/ja/icons.mdx
+++ b/docs/ja/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 概要
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/ja/lucide.mdx
+++ b/docs/ja/lucide.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/ja/mdi.mdx
+++ b/docs/ja/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/ja/phosphor.mdx
+++ b/docs/ja/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/ja/simple-icons.mdx
+++ b/docs/ja/simple-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/ja/tabler.mdx
+++ b/docs/ja/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/ko/aws.mdx
+++ b/docs/ko/aws.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/ko/azure.mdx
+++ b/docs/ko/azure.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/ko/brand.mdx
+++ b/docs/ko/brand.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: F5 브랜드
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/ko/carbon.mdx
+++ b/docs/ko/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/ko/cloud-icons.mdx
+++ b/docs/ko/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 클라우드 개요
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/ko/f5xc.mdx
+++ b/docs/ko/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/ko/gcp.mdx
+++ b/docs/ko/gcp.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/ko/hashicorp-flight.mdx
+++ b/docs/ko/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/ko/iconify-packs.mdx
+++ b/docs/ko/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify 개요
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/ko/icons.mdx
+++ b/docs/ko/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 개요
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/ko/lucide.mdx
+++ b/docs/ko/lucide.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/ko/mdi.mdx
+++ b/docs/ko/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/ko/phosphor.mdx
+++ b/docs/ko/phosphor.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/ko/simple-icons.mdx
+++ b/docs/ko/simple-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/ko/tabler.mdx
+++ b/docs/ko/tabler.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/pt-br/aws.mdx
+++ b/docs/pt-br/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/pt-br/azure.mdx
+++ b/docs/pt-br/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/pt-br/brand.mdx
+++ b/docs/pt-br/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Marca F5
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/pt-br/carbon.mdx
+++ b/docs/pt-br/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/pt-br/cloud-icons.mdx
+++ b/docs/pt-br/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Visão Geral da Nuvem
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/pt-br/f5xc.mdx
+++ b/docs/pt-br/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/pt-br/gcp.mdx
+++ b/docs/pt-br/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/pt-br/hashicorp-flight.mdx
+++ b/docs/pt-br/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/pt-br/iconify-packs.mdx
+++ b/docs/pt-br/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Visão Geral Iconify
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/pt-br/icons.mdx
+++ b/docs/pt-br/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Visão Geral
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/pt-br/lucide.mdx
+++ b/docs/pt-br/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/pt-br/mdi.mdx
+++ b/docs/pt-br/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/pt-br/phosphor.mdx
+++ b/docs/pt-br/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/pt-br/simple-icons.mdx
+++ b/docs/pt-br/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/pt-br/tabler.mdx
+++ b/docs/pt-br/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/th/aws.mdx
+++ b/docs/th/aws.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/th/azure.mdx
+++ b/docs/th/azure.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/th/brand.mdx
+++ b/docs/th/brand.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: แบรนด์ F5
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/th/carbon.mdx
+++ b/docs/th/carbon.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/th/cloud-icons.mdx
+++ b/docs/th/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: ภาพรวมคลาวด์
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/th/f5xc.mdx
+++ b/docs/th/f5xc.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/th/gcp.mdx
+++ b/docs/th/gcp.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/th/hashicorp-flight.mdx
+++ b/docs/th/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/th/iconify-packs.mdx
+++ b/docs/th/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: ภาพรวม Iconify
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/th/icons.mdx
+++ b/docs/th/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: ภาพรวม
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/th/lucide.mdx
+++ b/docs/th/lucide.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/th/mdi.mdx
+++ b/docs/th/mdi.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/th/phosphor.mdx
+++ b/docs/th/phosphor.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/th/simple-icons.mdx
+++ b/docs/th/simple-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/th/tabler.mdx
+++ b/docs/th/tabler.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/zh-cn/aws.mdx
+++ b/docs/zh-cn/aws.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/zh-cn/azure.mdx
+++ b/docs/zh-cn/azure.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/zh-cn/brand.mdx
+++ b/docs/zh-cn/brand.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: F5 品牌
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/zh-cn/carbon.mdx
+++ b/docs/zh-cn/carbon.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/zh-cn/cloud-icons.mdx
+++ b/docs/zh-cn/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 云概览
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/zh-cn/f5xc.mdx
+++ b/docs/zh-cn/f5xc.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/zh-cn/gcp.mdx
+++ b/docs/zh-cn/gcp.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/zh-cn/hashicorp-flight.mdx
+++ b/docs/zh-cn/hashicorp-flight.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/zh-cn/iconify-packs.mdx
+++ b/docs/zh-cn/iconify-packs.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Iconify 概览
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/zh-cn/icons.mdx
+++ b/docs/zh-cn/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 概览
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/zh-cn/lucide.mdx
+++ b/docs/zh-cn/lucide.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/zh-cn/mdi.mdx
+++ b/docs/zh-cn/mdi.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/zh-cn/phosphor.mdx
+++ b/docs/zh-cn/phosphor.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/zh-cn/simple-icons.mdx
+++ b/docs/zh-cn/simple-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/zh-cn/tabler.mdx
+++ b/docs/zh-cn/tabler.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 

--- a/docs/zh-tw/aws.mdx
+++ b/docs/zh-tw/aws.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: AWS
   order: 14
 i18n:
-  sourceHash: 2a0dc369902e
+  sourceHash: f3f0054e8f0d
   translator: machine
 ---
 

--- a/docs/zh-tw/azure.mdx
+++ b/docs/zh-tw/azure.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Azure
   order: 15
 i18n:
-  sourceHash: 9ce4630285f8
+  sourceHash: 70d85f96dd59
   translator: machine
 ---
 

--- a/docs/zh-tw/brand.mdx
+++ b/docs/zh-tw/brand.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: F5 品牌
   order: 4
 i18n:
-  sourceHash: 015b61a8dc74
+  sourceHash: 5e7fa71d7ae9
   translator: machine
 ---
 

--- a/docs/zh-tw/carbon.mdx
+++ b/docs/zh-tw/carbon.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Carbon
   order: 7
 i18n:
-  sourceHash: c4fd1e4f8504
+  sourceHash: 0a79028bbba7
   translator: machine
 ---
 

--- a/docs/zh-tw/cloud-icons.mdx
+++ b/docs/zh-tw/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 雲端概覽
   order: 17
 i18n:
-  sourceHash: ab8b89e21cd1
+  sourceHash: bb67c0118b5a
   translator: machine
 ---
 

--- a/docs/zh-tw/f5xc.mdx
+++ b/docs/zh-tw/f5xc.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: F5 XC
   order: 13
 i18n:
-  sourceHash: f3575ddb94ed
+  sourceHash: a207cc88b31c
   translator: machine
 ---
 

--- a/docs/zh-tw/gcp.mdx
+++ b/docs/zh-tw/gcp.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: GCP
   order: 16
 i18n:
-  sourceHash: 3834429676c4
+  sourceHash: ceb6c0be6a66
   translator: machine
 ---
 

--- a/docs/zh-tw/hashicorp-flight.mdx
+++ b/docs/zh-tw/hashicorp-flight.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: HashiCorp Flight
   order: 12
 i18n:
-  sourceHash: ee33d449ab82
+  sourceHash: b5303074fadd
   translator: machine
 ---
 

--- a/docs/zh-tw/iconify-packs.mdx
+++ b/docs/zh-tw/iconify-packs.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Iconify 概覽
   order: 10
 i18n:
-  sourceHash: 853482de4a8c
+  sourceHash: 93fd4bb42ed6
   translator: machine
 ---
 

--- a/docs/zh-tw/icons.mdx
+++ b/docs/zh-tw/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 概覽
   order: 2
 i18n:
-  sourceHash: 2da27471772e
+  sourceHash: cf182766b8d2
   translator: machine
 ---
 

--- a/docs/zh-tw/lucide.mdx
+++ b/docs/zh-tw/lucide.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Lucide
   order: 5
 i18n:
-  sourceHash: 5b1042a43a30
+  sourceHash: 38423a9e5b52
   translator: machine
 ---
 

--- a/docs/zh-tw/mdi.mdx
+++ b/docs/zh-tw/mdi.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Material Design
   order: 6
 i18n:
-  sourceHash: '1211107e2988'
+  sourceHash: '6b38e5c340ae'
   translator: machine
 ---
 

--- a/docs/zh-tw/phosphor.mdx
+++ b/docs/zh-tw/phosphor.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Phosphor
   order: 8
 i18n:
-  sourceHash: 65e65d0eee60
+  sourceHash: fb3d65693345
   translator: machine
 ---
 

--- a/docs/zh-tw/simple-icons.mdx
+++ b/docs/zh-tw/simple-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Simple Icons
   order: 11
 i18n:
-  sourceHash: 1863eeb200dc
+  sourceHash: e41826d6d1eb
   translator: machine
 ---
 

--- a/docs/zh-tw/tabler.mdx
+++ b/docs/zh-tw/tabler.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Tabler
   order: 9
 i18n:
-  sourceHash: 30e94af8ab51
+  sourceHash: f602153b69f2
   translator: machine
 ---
 


### PR DESCRIPTION
## Problem

`audit / Translation freshness` fails on 180 machine-translated locale files, blocking governance sync PR #619. Root cause: the org-rename sweep (`f5xc-salesdemos` → `f5-sales-demo`) updated en+locale content but did not restamp `i18n.sourceHash`.

Verified content-current: the only en change since each stored hash is the org rename, already applied in the locale files (guard confirmed org-rename-only for every file; 0 needing re-translation).

## Fix

Restamp `i18n.sourceHash` to `sha256(en)[:12]` in the 180 affected files. One hash line per file; no prose edits.

## Acceptance criteria
- [ ] `audit / Translation freshness` passes.
- [ ] Only `sourceHash` values change.

Unblocks governance sync PR #619.

Closes #620