### PR TITLE
fix: point icon-set table links to upstream sites (#647)

### DIFF
--- a/docs/ar/cloud-icons.mdx
+++ b/docs/ar/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: نظرة عامة على السحابة
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ i18n:
 
 | الحزمة | الأيقونات | الحجم الافتراضي | الصفحة |
 |------|-------|-------------|------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## الاستخدام
 

--- a/docs/ar/iconify-packs.mdx
+++ b/docs/ar/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: نظرة عامة على Iconify
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -17,10 +17,10 @@ i18n:
 
 | الحزمة | البادئة | الأيقونات | النمط | الأفضل لـ | الصفحة |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | معبأة + مخططة | أغراض عامة، أوسع تغطية | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | مخططة | تصميم المؤسسات/IBM، خطوط نظيفة | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | أوزان متعددة | خيارات أوزان مرنة (من الرفيع إلى المعبأ) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | قائمة على الحدود | أيقونات خطية واضحة، حدود متسقة | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | معبأة + مخططة | أغراض عامة، أوسع تغطية | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | مخططة | تصميم المؤسسات/IBM، خطوط نظيفة | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | أوزان متعددة | خيارات أوزان مرنة (من الرفيع إلى المعبأ) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | قائمة على الحدود | أيقونات خطية واضحة، حدود متسقة | [Tabler](https://tabler.io/icons) |
 
 ## الاستخدام
 

--- a/docs/ar/icons.mdx
+++ b/docs/ar/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: نظرة عامة
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | الحزمة | العدد | الاستخدام | الصفحة |
 |------|-------|-------|------|
-| Starlight المدمجة | ~200 | `<Icon name="star" />` | [Starlight المدمجة](/starlight/) |
-| علامة F5 التجارية | 665 | `<Icon name="ai-admin" />` | [علامة F5 التجارية](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| خدمات F5 XC | 30 | `<Icon name="bot-defense" />` | [خدمات F5 XC](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| بنية AWS | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| بنية Azure | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| بنية GCP | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight المدمجة | ~200 | `<Icon name="star" />` | [Starlight المدمجة](https://starlight.astro.build/) |
+| علامة F5 التجارية | 665 | `<Icon name="ai-admin" />` | علامة F5 التجارية |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| خدمات F5 XC | 30 | `<Icon name="bot-defense" />` | خدمات F5 XC |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| بنية AWS | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| بنية Azure | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| بنية GCP | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## طريقة العرض
 

--- a/docs/de/cloud-icons.mdx
+++ b/docs/de/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Cloud-Übersicht
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ Drei Icon-Pakete stellen farbige Service-Icons für die Dokumentation von Cloud-
 
 | Paket | Icons | Standardgröße | Seite |
 |-------|-------|---------------|-------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## Verwendung
 

--- a/docs/de/iconify-packs.mdx
+++ b/docs/de/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify Übersicht
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -17,10 +17,10 @@ Mehrere Iconify-Icon-Pakete sind als npm-Pakete mit Astro `Icon`-Komponenten ver
 
 | Paket | Präfix | Icons | Stil | Ideal für | Seite |
 |-------|--------|-------|------|-----------|-------|
-| Material Design | `mdi` | 7.638 | Gefüllt + umrandet | Allgemeine Nutzung, breiteste Abdeckung | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2.582 | Umrandet | Enterprise/IBM-Design, klare Linien | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9.161 | Mehrere Strichstärken | Flexible Strichstärkenoptionen (dünn bis gefüllt) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6.034 | Strichbasiert | Klare Linien-Icons, einheitliche Strichstärke | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7.638 | Gefüllt + umrandet | Allgemeine Nutzung, breiteste Abdeckung | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2.582 | Umrandet | Enterprise/IBM-Design, klare Linien | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9.161 | Mehrere Strichstärken | Flexible Strichstärkenoptionen (dünn bis gefüllt) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6.034 | Strichbasiert | Klare Linien-Icons, einheitliche Strichstärke | [Tabler](https://tabler.io/icons) |
 
 ## Verwendung
 

--- a/docs/de/icons.mdx
+++ b/docs/de/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Überblick
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ Das Dokumentationsthema bietet Zugriff auf Tausende von Icons aus mehreren Paket
 
 | Paket | Anzahl | Verwendung | Seite |
 |-------|--------|------------|-------|
-| Starlight Integriert | ~200 | `<Icon name="star" />` | [Starlight Integriert](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1.600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7.638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2.582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9.161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6.034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3.200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight Integriert | ~200 | `<Icon name="star" />` | [Starlight Integriert](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1.600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7.638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2.582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9.161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6.034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3.200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## Rendering-Methode
 

--- a/docs/en/cloud-icons.mdx
+++ b/docs/en/cloud-icons.mdx
@@ -12,9 +12,9 @@ Three icon packs provide color service icons for documenting cloud infrastructur
 
 | Pack | Icons | Default Size | Page |
 |------|-------|-------------|------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## Usage
 

--- a/docs/en/iconify-packs.mdx
+++ b/docs/en/iconify-packs.mdx
@@ -12,10 +12,10 @@ Multiple Iconify icon packs are available as npm packages with Astro `Icon` comp
 
 | Pack | Prefix | Icons | Style | Best For | Page |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | Filled + outlined | General-purpose, broadest coverage | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | Outlined | Enterprise/IBM design, clean lines | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | Multiple weights | Flexible weight options (thin to fill) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | Stroke-based | Crisp line icons, consistent stroke | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | Filled + outlined | General-purpose, broadest coverage | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | Outlined | Enterprise/IBM design, clean lines | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | Multiple weights | Flexible weight options (thin to fill) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | Stroke-based | Crisp line icons, consistent stroke | [Tabler](https://tabler.io/icons) |
 
 ## Usage
 

--- a/docs/en/icons.mdx
+++ b/docs/en/icons.mdx
@@ -18,19 +18,19 @@ The documentation theme provides access to thousands of icons from multiple pack
 
 | Pack | Count | Usage | Page |
 |------|-------|-------|------|
-| Starlight Built-in | ~200 | `<Icon name="star" />` | [Starlight Built-in](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight Built-in | ~200 | `<Icon name="star" />` | [Starlight Built-in](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## Rendering Method
 

--- a/docs/es/cloud-icons.mdx
+++ b/docs/es/cloud-icons.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Descripción general de la nube
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -18,9 +18,9 @@ Tres paquetes de iconos proporcionan iconos de servicios a color para documentar
 
 | Paquete | Iconos | Tamaño predeterminado | Página |
 |---------|--------|----------------------|--------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## Uso
 

--- a/docs/es/iconify-packs.mdx
+++ b/docs/es/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Resumen de Iconify
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -18,10 +18,10 @@ Múltiples paquetes de iconos Iconify están disponibles como paquetes npm con c
 
 | Paquete | Prefijo | Iconos | Estilo | Ideal Para | Página |
 |---------|---------|--------|--------|------------|--------|
-| Material Design | `mdi` | 7,638 | Relleno + contorno | Uso general, mayor cobertura | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | Contorno | Diseño empresarial/IBM, líneas limpias | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | Múltiples grosores | Opciones flexibles de grosor (fino a relleno) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | Basado en trazo | Iconos de línea nítidos, trazo consistente | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | Relleno + contorno | Uso general, mayor cobertura | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | Contorno | Diseño empresarial/IBM, líneas limpias | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | Múltiples grosores | Opciones flexibles de grosor (fino a relleno) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | Basado en trazo | Iconos de línea nítidos, trazo consistente | [Tabler](https://tabler.io/icons) |
 
 ## Uso
 

--- a/docs/es/icons.mdx
+++ b/docs/es/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Descripción general
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ El tema de documentación proporciona acceso a miles de iconos de múltiples paq
 
 | Paquete | Cantidad | Uso | Página |
 |---------|----------|-----|--------|
-| Starlight Integrado | ~200 | `<Icon name="star" />` | [Starlight Integrado](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight Integrado | ~200 | `<Icon name="star" />` | [Starlight Integrado](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## Método de Renderizado
 

--- a/docs/fr/cloud-icons.mdx
+++ b/docs/fr/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Aperçu Cloud
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ Trois packs d'icônes fournissent des icônes de services en couleur pour docume
 
 | Pack | Icônes | Taille par défaut | Page |
 |------|--------|-------------------|------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## Utilisation
 

--- a/docs/fr/iconify-packs.mdx
+++ b/docs/fr/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Aperçu Iconify
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -18,10 +18,10 @@ Plusieurs packs d'icônes Iconify sont disponibles sous forme de packages npm av
 
 | Pack | Préfixe | Icônes | Style | Idéal pour | Page |
 |------|---------|--------|-------|------------|------|
-| Material Design | `mdi` | 7 638 | Rempli + contour | Usage général, couverture la plus large | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2 582 | Contour | Design entreprise/IBM, lignes épurées | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9 161 | Poids multiples | Options de poids flexibles (fin à rempli) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6 034 | Basé sur les traits | Icônes linéaires nettes, trait uniforme | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7 638 | Rempli + contour | Usage général, couverture la plus large | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2 582 | Contour | Design entreprise/IBM, lignes épurées | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9 161 | Poids multiples | Options de poids flexibles (fin à rempli) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6 034 | Basé sur les traits | Icônes linéaires nettes, trait uniforme | [Tabler](https://tabler.io/icons) |
 
 ## Utilisation
 

--- a/docs/fr/icons.mdx
+++ b/docs/fr/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Aperçu
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ Le thème de documentation fournit l'accès à des milliers d'icônes provenant 
 
 | Pack | Nombre | Utilisation | Page |
 |------|--------|-------------|------|
-| Starlight intégré | ~200 | `<Icon name="star" />` | [Starlight intégré](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1 600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7 638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2 582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9 161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6 034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3 200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight intégré | ~200 | `<Icon name="star" />` | [Starlight intégré](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1 600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7 638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2 582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9 161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6 034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3 200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## Méthode de rendu
 

--- a/docs/hi/cloud-icons.mdx
+++ b/docs/hi/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: क्लाउड अवलोकन
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ i18n:
 
 | पैक | आइकन | डिफ़ॉल्ट आकार | पृष्ठ |
 |------|-------|-------------|------|
-| AWS आर्किटेक्चर | 885 | 48x48 | [AWS](/aws/) |
-| Azure आर्किटेक्चर | 606 | 18x18 | [Azure](/azure/) |
-| GCP आर्किटेक्चर | 216 | 24x24 | [GCP](/gcp/) |
+| AWS आर्किटेक्चर | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure आर्किटेक्चर | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP आर्किटेक्चर | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## उपयोग
 

--- a/docs/hi/iconify-packs.mdx
+++ b/docs/hi/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify अवलोकन
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -17,10 +17,10 @@ i18n:
 
 | पैक | प्रीफिक्स | आइकन | शैली | सबसे उपयुक्त | पृष्ठ |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | फिल्ड + आउटलाइन्ड | सामान्य-उपयोग, सबसे व्यापक कवरेज | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | आउटलाइन्ड | एंटरप्राइज/IBM डिज़ाइन, स्पष्ट रेखाएँ | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | विभिन्न वज़न | लचीले वज़न विकल्प (थिन से फिल तक) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | स्ट्रोक-आधारित | स्पष्ट लाइन आइकन, सुसंगत स्ट्रोक | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | फिल्ड + आउटलाइन्ड | सामान्य-उपयोग, सबसे व्यापक कवरेज | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | आउटलाइन्ड | एंटरप्राइज/IBM डिज़ाइन, स्पष्ट रेखाएँ | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | विभिन्न वज़न | लचीले वज़न विकल्प (थिन से फिल तक) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | स्ट्रोक-आधारित | स्पष्ट लाइन आइकन, सुसंगत स्ट्रोक | [Tabler](https://tabler.io/icons) |
 
 ## उपयोग
 

--- a/docs/hi/icons.mdx
+++ b/docs/hi/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: अवलोकन
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | पैक | संख्या | उपयोग | पेज |
 |------|-------|-------|------|
-| Starlight बिल्ट-इन | ~200 | `<Icon name="star" />` | [Starlight बिल्ट-इन](/starlight/) |
-| F5 ब्रांड | 665 | `<Icon name="ai-admin" />` | [F5 ब्रांड](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC सर्विसेज | 30 | `<Icon name="bot-defense" />` | [F5 XC सर्विसेज](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS आर्किटेक्चर | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure आर्किटेक्चर | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP आर्किटेक्चर | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight बिल्ट-इन | ~200 | `<Icon name="star" />` | [Starlight बिल्ट-इन](https://starlight.astro.build/) |
+| F5 ब्रांड | 665 | `<Icon name="ai-admin" />` | F5 ब्रांड |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC सर्विसेज | 30 | `<Icon name="bot-defense" />` | F5 XC सर्विसेज |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS आर्किटेक्चर | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure आर्किटेक्चर | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP आर्किटेक्चर | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## रेंडरिंग विधि
 

--- a/docs/it/cloud-icons.mdx
+++ b/docs/it/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Panoramica Cloud
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ Tre pacchetti di icone forniscono icone colorate per i servizi utilizzati nella 
 
 | Pacchetto | Icone | Dimensione predefinita | Pagina |
 |-----------|-------|----------------------|--------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## Utilizzo
 

--- a/docs/it/iconify-packs.mdx
+++ b/docs/it/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Panoramica Iconify
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -18,10 +18,10 @@ Sono disponibili diversi pacchetti di icone Iconify come pacchetti npm con compo
 
 | Pacchetto | Prefisso | Icone | Stile | Ideale per | Pagina |
 |-----------|----------|-------|-------|------------|--------|
-| Material Design | `mdi` | 7.638 | Filled + outlined | Uso generico, copertura più ampia | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2.582 | Outlined | Design enterprise/IBM, linee pulite | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9.161 | Pesi multipli | Opzioni di peso flessibili (da thin a fill) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6.034 | Basato su tratti | Icone a linee nitide, tratto uniforme | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7.638 | Filled + outlined | Uso generico, copertura più ampia | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2.582 | Outlined | Design enterprise/IBM, linee pulite | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9.161 | Pesi multipli | Opzioni di peso flessibili (da thin a fill) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6.034 | Basato su tratti | Icone a linee nitide, tratto uniforme | [Tabler](https://tabler.io/icons) |
 
 ## Utilizzo
 

--- a/docs/it/icons.mdx
+++ b/docs/it/icons.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Panoramica
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -24,19 +24,19 @@ Il tema della documentazione fornisce accesso a migliaia di icone da molteplici 
 
 | Pacchetto | Quantità | Utilizzo | Pagina |
 |-----------|----------|----------|--------|
-| Starlight Integrato | ~200 | `<Icon name="star" />` | [Starlight Integrato](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1.600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7.638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2.582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9.161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6.034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3.200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight Integrato | ~200 | `<Icon name="star" />` | [Starlight Integrato](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1.600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7.638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2.582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9.161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6.034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3.200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## Metodo di Rendering
 

--- a/docs/ja/cloud-icons.mdx
+++ b/docs/ja/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: クラウド概要
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -15,9 +15,9 @@ i18n:
 
 | パック | アイコン数 | デフォルトサイズ | ページ |
 |------|-------|-------------|------|
-| AWS アーキテクチャ | 885 | 48x48 | [AWS](/aws/) |
-| Azure アーキテクチャ | 606 | 18x18 | [Azure](/azure/) |
-| GCP アーキテクチャ | 216 | 24x24 | [GCP](/gcp/) |
+| AWS アーキテクチャ | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure アーキテクチャ | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP アーキテクチャ | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## 使い方
 

--- a/docs/ja/iconify-packs.mdx
+++ b/docs/ja/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify 概要
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -17,10 +17,10 @@ i18n:
 
 | パック | プレフィックス | アイコン数 | スタイル | 最適な用途 | ページ |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | 塗りつぶし + アウトライン | 汎用、最も幅広いカバレッジ | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | アウトライン | エンタープライズ/IBM デザイン、クリーンなライン | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | 複数のウェイト | 柔軟なウェイトオプション（thin から fill まで） | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | ストロークベース | シャープなラインアイコン、一貫したストローク | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | 塗りつぶし + アウトライン | 汎用、最も幅広いカバレッジ | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | アウトライン | エンタープライズ/IBM デザイン、クリーンなライン | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | 複数のウェイト | 柔軟なウェイトオプション（thin から fill まで） | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | ストロークベース | シャープなラインアイコン、一貫したストローク | [Tabler](https://tabler.io/icons) |
 
 ## 使用方法
 

--- a/docs/ja/icons.mdx
+++ b/docs/ja/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 概要
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -21,19 +21,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | パック | 数 | 使用方法 | ページ |
 |------|-------|-------|------|
-| Starlight 組み込み | 約200 | `<Icon name="star" />` | [Starlight 組み込み](/starlight/) |
-| F5 ブランド | 665 | `<Icon name="ai-admin" />` | [F5 ブランド](/brand/) |
-| Lucide | 約1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC サービス | 30 | `<Icon name="bot-defense" />` | [F5 XC サービス](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS アーキテクチャ | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure アーキテクチャ | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP アーキテクチャ | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight 組み込み | 約200 | `<Icon name="star" />` | [Starlight 組み込み](https://starlight.astro.build/) |
+| F5 ブランド | 665 | `<Icon name="ai-admin" />` | F5 ブランド |
+| Lucide | 約1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC サービス | 30 | `<Icon name="bot-defense" />` | F5 XC サービス |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS アーキテクチャ | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure アーキテクチャ | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP アーキテクチャ | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## レンダリング方法
 

--- a/docs/ko/cloud-icons.mdx
+++ b/docs/ko/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 클라우드 개요
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -15,9 +15,9 @@ i18n:
 
 | 팩 | 아이콘 수 | 기본 크기 | 페이지 |
 |------|-------|-------------|------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## 사용법
 

--- a/docs/ko/iconify-packs.mdx
+++ b/docs/ko/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Iconify 개요
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -17,10 +17,10 @@ i18n:
 
 | 팩 | 접두사 | 아이콘 수 | 스타일 | 최적 용도 | 페이지 |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | Filled + outlined | 범용, 가장 넓은 커버리지 | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | Outlined | 엔터프라이즈/IBM 디자인, 깔끔한 선 | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | 다양한 굵기 | 유연한 굵기 옵션 (thin에서 fill까지) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | Stroke 기반 | 선명한 라인 아이콘, 일관된 stroke | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | Filled + outlined | 범용, 가장 넓은 커버리지 | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | Outlined | 엔터프라이즈/IBM 디자인, 깔끔한 선 | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | 다양한 굵기 | 유연한 굵기 옵션 (thin에서 fill까지) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | Stroke 기반 | 선명한 라인 아이콘, 일관된 stroke | [Tabler](https://tabler.io/icons) |
 
 ## 사용법
 

--- a/docs/ko/icons.mdx
+++ b/docs/ko/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 개요
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -21,19 +21,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | 팩 | 수량 | 사용법 | 페이지 |
 |------|-------|-------|------|
-| Starlight 내장 | ~200 | `<Icon name="star" />` | [Starlight 내장](/starlight/) |
-| F5 브랜드 | 665 | `<Icon name="ai-admin" />` | [F5 브랜드](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC 서비스 | 30 | `<Icon name="bot-defense" />` | [F5 XC 서비스](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS 아키텍처 | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure 아키텍처 | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP 아키텍처 | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight 내장 | ~200 | `<Icon name="star" />` | [Starlight 내장](https://starlight.astro.build/) |
+| F5 브랜드 | 665 | `<Icon name="ai-admin" />` | F5 브랜드 |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC 서비스 | 30 | `<Icon name="bot-defense" />` | F5 XC 서비스 |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS 아키텍처 | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure 아키텍처 | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP 아키텍처 | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## 렌더링 방식
 

--- a/docs/pt-br/cloud-icons.mdx
+++ b/docs/pt-br/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Visão Geral da Nuvem
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ Três pacotes de ícones fornecem ícones coloridos de serviços para documenta�
 
 | Pacote | Ícones | Tamanho Padrão | Página |
 |--------|--------|----------------|--------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## Uso
 

--- a/docs/pt-br/iconify-packs.mdx
+++ b/docs/pt-br/iconify-packs.mdx
@@ -8,7 +8,7 @@ sidebar:
   label: Visão Geral Iconify
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -18,10 +18,10 @@ Múltiplos pacotes de ícones Iconify estão disponíveis como pacotes npm com c
 
 | Pacote | Prefixo | Ícones | Estilo | Melhor Para | Página |
 |--------|---------|--------|--------|-------------|--------|
-| Material Design | `mdi` | 7.638 | Preenchido + contorno | Uso geral, cobertura mais ampla | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2.582 | Contorno | Design empresarial/IBM, linhas limpas | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9.161 | Múltiplos pesos | Opções flexíveis de peso (fino a preenchido) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6.034 | Baseado em traço | Ícones de linha nítidos, traço consistente | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7.638 | Preenchido + contorno | Uso geral, cobertura mais ampla | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2.582 | Contorno | Design empresarial/IBM, linhas limpas | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9.161 | Múltiplos pesos | Opções flexíveis de peso (fino a preenchido) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6.034 | Baseado em traço | Ícones de linha nítidos, traço consistente | [Tabler](https://tabler.io/icons) |
 
 ## Uso
 

--- a/docs/pt-br/icons.mdx
+++ b/docs/pt-br/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Visão Geral
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ O tema de documentação fornece acesso a milhares de ícones de múltiplos paco
 
 | Pacote | Quantidade | Uso | Página |
 |--------|-----------|-----|--------|
-| Starlight Integrado | ~200 | `<Icon name="star" />` | [Starlight Integrado](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1.600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7.638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2.582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9.161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6.034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3.200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight Integrado | ~200 | `<Icon name="star" />` | [Starlight Integrado](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1.600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7.638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2.582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9.161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6.034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3.200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## Método de Renderização
 

--- a/docs/th/cloud-icons.mdx
+++ b/docs/th/cloud-icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: ภาพรวมคลาวด์
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -17,9 +17,9 @@ i18n:
 
 | ชุด | ไอคอน | ขนาดเริ่มต้น | หน้า |
 |------|-------|-------------|------|
-| AWS Architecture | 885 | 48x48 | [AWS](/aws/) |
-| Azure Architecture | 606 | 18x18 | [Azure](/azure/) |
-| GCP Architecture | 216 | 24x24 | [GCP](/gcp/) |
+| AWS Architecture | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## การใช้งาน
 

--- a/docs/th/iconify-packs.mdx
+++ b/docs/th/iconify-packs.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: ภาพรวม Iconify
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -17,10 +17,10 @@ i18n:
 
 | ชุดไอคอน | คำนำหน้า | จำนวนไอคอน | สไตล์ | เหมาะสำหรับ | หน้า |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | แบบเติมสี + แบบเส้นขอบ | ใช้งานทั่วไป ครอบคลุมกว้างที่สุด | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | แบบเส้นขอบ | งานออกแบบระดับองค์กร/IBM เส้นสะอาด | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | หลายน้ำหนัก | ตัวเลือกน้ำหนักที่ยืดหยุ่น (จากบางถึงเติมสี) | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | แบบเส้นขีด | ไอคอนเส้นคมชัด ความหนาเส้นขีดสม่ำเสมอ | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | แบบเติมสี + แบบเส้นขอบ | ใช้งานทั่วไป ครอบคลุมกว้างที่สุด | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | แบบเส้นขอบ | งานออกแบบระดับองค์กร/IBM เส้นสะอาด | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | หลายน้ำหนัก | ตัวเลือกน้ำหนักที่ยืดหยุ่น (จากบางถึงเติมสี) | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | แบบเส้นขีด | ไอคอนเส้นคมชัด ความหนาเส้นขีดสม่ำเสมอ | [Tabler](https://tabler.io/icons) |
 
 ## การใช้งาน
 

--- a/docs/th/icons.mdx
+++ b/docs/th/icons.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: ภาพรวม
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -23,19 +23,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | ชุด | จำนวน | การใช้งาน | หน้า |
 |------|-------|-------|------|
-| Starlight ในตัว | ~200 | `<Icon name="star" />` | [Starlight ในตัว](/starlight/) |
-| F5 Brand | 665 | `<Icon name="ai-admin" />` | [F5 Brand](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC Services | 30 | `<Icon name="bot-defense" />` | [F5 XC Services](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight ในตัว | ~200 | `<Icon name="star" />` | [Starlight ในตัว](https://starlight.astro.build/) |
+| F5 Brand | 665 | `<Icon name="ai-admin" />` | F5 Brand |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC Services | 30 | `<Icon name="bot-defense" />` | F5 XC Services |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS Architecture | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure Architecture | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP Architecture | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## วิธีการเรนเดอร์
 

--- a/docs/zh-cn/cloud-icons.mdx
+++ b/docs/zh-cn/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 云概览
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -15,9 +15,9 @@ i18n:
 
 | 图标包 | 图标数量 | 默认尺寸 | 页面 |
 |------|-------|-------------|------|
-| AWS 架构 | 885 | 48x48 | [AWS](/aws/) |
-| Azure 架构 | 606 | 18x18 | [Azure](/azure/) |
-| GCP 架构 | 216 | 24x24 | [GCP](/gcp/) |
+| AWS 架构 | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure 架构 | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP 架构 | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## 用法
 

--- a/docs/zh-cn/iconify-packs.mdx
+++ b/docs/zh-cn/iconify-packs.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Iconify 概览
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -15,10 +15,10 @@ i18n:
 
 | 图标包 | 前缀 | 图标数量 | 风格 | 最适用于 | 页面 |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | 填充 + 轮廓 | 通用场景，覆盖范围最广 | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | 轮廓 | 企业/IBM 设计，线条简洁 | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | 多种粗细 | 灵活的粗细选项（从细到填充） | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | 描边风格 | 清晰的线条图标，一致的描边 | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | 填充 + 轮廓 | 通用场景，覆盖范围最广 | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | 轮廓 | 企业/IBM 设计，线条简洁 | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | 多种粗细 | 灵活的粗细选项（从细到填充） | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | 描边风格 | 清晰的线条图标，一致的描边 | [Tabler](https://tabler.io/icons) |
 
 ## 使用方法
 

--- a/docs/zh-cn/icons.mdx
+++ b/docs/zh-cn/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 概览
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -21,19 +21,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | 图标包 | 数量 | 用法 | 页面 |
 |------|-------|-------|------|
-| Starlight 内置 | ~200 | `<Icon name="star" />` | [Starlight 内置](/starlight/) |
-| F5 品牌 | 665 | `<Icon name="ai-admin" />` | [F5 品牌](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC 服务 | 30 | `<Icon name="bot-defense" />` | [F5 XC 服务](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS 架构 | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure 架构 | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP 架构 | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight 内置 | ~200 | `<Icon name="star" />` | [Starlight 内置](https://starlight.astro.build/) |
+| F5 品牌 | 665 | `<Icon name="ai-admin" />` | F5 品牌 |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC 服务 | 30 | `<Icon name="bot-defense" />` | F5 XC 服务 |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS 架构 | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure 架构 | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP 架构 | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## 渲染方式
 

--- a/docs/zh-tw/cloud-icons.mdx
+++ b/docs/zh-tw/cloud-icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 雲端概覽
   order: 17
 i18n:
-  sourceHash: bb67c0118b5a
+  sourceHash: fc86103df68e
   translator: machine
 ---
 
@@ -15,9 +15,9 @@ i18n:
 
 | 套件 | 圖示數量 | 預設尺寸 | 頁面 |
 |------|-------|-------------|------|
-| AWS 架構 | 885 | 48x48 | [AWS](/aws/) |
-| Azure 架構 | 606 | 18x18 | [Azure](/azure/) |
-| GCP 架構 | 216 | 24x24 | [GCP](/gcp/) |
+| AWS 架構 | 885 | 48x48 | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure 架構 | 606 | 18x18 | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP 架構 | 216 | 24x24 | [GCP](https://cloud.google.com/icons) |
 
 ## 使用方式
 

--- a/docs/zh-tw/iconify-packs.mdx
+++ b/docs/zh-tw/iconify-packs.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Iconify 概覽
   order: 10
 i18n:
-  sourceHash: 93fd4bb42ed6
+  sourceHash: 0b13aeb930b7
   translator: machine
 ---
 
@@ -15,10 +15,10 @@ i18n:
 
 | 套件 | 前綴 | 圖示數量 | 風格 | 最適用於 | 頁面 |
 |------|--------|-------|-------|----------|------|
-| Material Design | `mdi` | 7,638 | 填充 + 描邊 | 通用用途，涵蓋範圍最廣 | [Material Design](/mdi/) |
-| Carbon | `carbon` | 2,582 | 描邊 | 企業/IBM 設計，線條簡潔 | [Carbon](/carbon/) |
-| Phosphor | `ph` | 9,161 | 多種粗細 | 彈性粗細選項（從極細到填充） | [Phosphor](/phosphor/) |
-| Tabler | `tabler` | 6,034 | 筆畫式 | 清晰的線條圖示，一致的筆畫 | [Tabler](/tabler/) |
+| Material Design | `mdi` | 7,638 | 填充 + 描邊 | 通用用途，涵蓋範圍最廣 | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | `carbon` | 2,582 | 描邊 | 企業/IBM 設計，線條簡潔 | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | `ph` | 9,161 | 多種粗細 | 彈性粗細選項（從極細到填充） | [Phosphor](https://phosphoricons.com/) |
+| Tabler | `tabler` | 6,034 | 筆畫式 | 清晰的線條圖示，一致的筆畫 | [Tabler](https://tabler.io/icons) |
 
 ## 使用方式
 

--- a/docs/zh-tw/icons.mdx
+++ b/docs/zh-tw/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: 概覽
   order: 2
 i18n:
-  sourceHash: cf182766b8d2
+  sourceHash: 56445f042821
   translator: machine
 ---
 
@@ -21,19 +21,19 @@ import TablerIcon from '@f5-sales-demo/icons-tabler/Icon.astro';
 
 | 套件 | 數量 | 使用方式 | 頁面 |
 |------|------|---------|------|
-| Starlight 內建 | ~200 | `<Icon name="star" />` | [Starlight 內建](/starlight/) |
-| F5 品牌 | 665 | `<Icon name="ai-admin" />` | [F5 品牌](/brand/) |
-| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](/lucide/) |
-| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](/mdi/) |
-| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](/carbon/) |
-| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](/phosphor/) |
-| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](/tabler/) |
-| F5 XC 服務 | 30 | `<Icon name="bot-defense" />` | [F5 XC 服務](/f5xc/) |
-| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](/simple-icons/) |
-| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](/hashicorp-flight/) |
-| AWS 架構 | 885 | `<Icon name="lambda" />` | [AWS](/aws/) |
-| Azure 架構 | 606 | `<Icon name="virtual-machine" />` | [Azure](/azure/) |
-| GCP 架構 | 216 | `<Icon name="cloud-storage" />` | [GCP](/gcp/) |
+| Starlight 內建 | ~200 | `<Icon name="star" />` | [Starlight 內建](https://starlight.astro.build/) |
+| F5 品牌 | 665 | `<Icon name="ai-admin" />` | F5 品牌 |
+| Lucide | ~1,600 | `<Icon name="rocket" />` | [Lucide](https://lucide.dev/) |
+| Material Design | 7,638 | `<Icon name="database" />` | [Material Design](https://pictogrammers.com/library/mdi/) |
+| Carbon | 2,582 | `<Icon name="cloud" />` | [Carbon](https://carbondesignsystem.com/elements/icons/library/) |
+| Phosphor | 9,161 | `<Icon name="globe" />` | [Phosphor](https://phosphoricons.com/) |
+| Tabler | 6,034 | `<Icon name="shield" />` | [Tabler](https://tabler.io/icons) |
+| F5 XC 服務 | 30 | `<Icon name="bot-defense" />` | F5 XC 服務 |
+| Simple Icons | 3,200+ | `<Icon name="cloudflare" />` | [Simple Icons](https://simpleicons.org/) |
+| HashiCorp Flight | 672 | `<Icon name="cloud" />` | [HashiCorp Flight](https://flight-hashicorp.vercel.app/) |
+| AWS 架構 | 885 | `<Icon name="lambda" />` | [AWS](https://aws.amazon.com/architecture/icons/) |
+| Azure 架構 | 606 | `<Icon name="virtual-machine" />` | [Azure](https://learn.microsoft.com/en-us/azure/architecture/icons/) |
+| GCP 架構 | 216 | `<Icon name="cloud-storage" />` | [GCP](https://cloud.google.com/icons) |
 
 ## 渲染方式
 


### PR DESCRIPTION
## Summary

The icon reference table linked each pack to a bogus local `/‹slug›/` path (404). Pointed each to its upstream project site (Lucide, Carbon, Phosphor, Tabler, Simple Icons, Material Design, HashiCorp Flight, Starlight, AWS/Azure/GCP architecture icons); delinked the two F5-custom sets (F5 Brand, F5 XC Services) that have no public upstream.

## Verification
- Residual bogus `](/‹slug›/)` links → **0**.
- Local translation-freshness audit → fresh.

Fixes #647