### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ tui-debug.log
 .nyc_output/
 packages/ai/test/.temp-images/
 docs/superpowers/
+.superpowers/
 !.xcsh/
 .xcsh/plugins/
 .xcsh/contexts/


### PR DESCRIPTION
Closes #675

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore