### PR TITLE
fix(ci): add least-privilege permissions to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,12 @@ on:
       - 'package-lock.json'
   workflow_dispatch:
 
+# Read-only default. Neither job needs a GITHUB_TOKEN write scope: `publish`
+# authenticates to npm with NPM_TOKEN, and `dispatch` calls the docs-builder
+# repository_dispatch API with RELEASE_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -135,6 +141,10 @@ jobs:
     name: Trigger docs-builder image rebuild
     needs: publish
     runs-on: ubuntu-latest
+    # The cross-repo dispatch authenticates with RELEASE_TOKEN, so GITHUB_TOKEN
+    # needs no write scope here.
+    permissions:
+      contents: read
     steps:
       - name: Dispatch rebuild-image to docs-builder
         env:


### PR DESCRIPTION
## Problem

The scheduled Workflow Security Audit (docs-control#775) fails on this repo. Both findings
are `excessive-permissions` in `npm-publish.yml`, and both are the "no `permissions:` block,
so the default token applies" shape:

```
warning[excessive-permissions] @ .github/workflows/npm-publish.yml:1:1     (workflow level)
warning[excessive-permissions] @ .github/workflows/npm-publish.yml:134:3   (dispatch job)
```

The `publish` job already declared `contents: read`; the workflow itself and the `dispatch`
job did not.

## Change

Added a read-only workflow default and an explicit `contents: read` on `dispatch`.

Neither job needs a `GITHUB_TOKEN` write scope, which is what makes this a safe tightening
rather than a guess:

- `publish` authenticates to npm with `NPM_TOKEN` (`NODE_AUTH_TOKEN`), not `GITHUB_TOKEN`.
- `dispatch` POSTs to `repos/f5-sales-demo/docs-builder/dispatches` with `RELEASE_TOKEN` —
  a cross-repo call that `GITHUB_TOKEN` could not authorise anyway.

## Verification

Run with zizmor **1.25.2**, the version super-linter pins.

| | exit | findings |
|---|---|---|
| before | 13 | 2 medium |
| after | **0** | **none, any severity** |

`actionlint` clean.

This is a publish path, so the next run should be confirmed to actually publish and to
still trigger the docs-builder rebuild — by artifact and by the downstream dispatch
landing, not by a green check alone.

Closes #700
