### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -29,6 +29,7 @@
     ".github/dependabot.yml",
     "CONTRIBUTING.md",
     "CLAUDE.md",
+    "STYLE_GUIDE.md",
     "README.md",
     ".editorconfig",
     ".gitignore",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease, pre-production code under active development; make clean-break changes, never add compatibility shims or keep deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
+- **Documentation style** — published content (guides, product documentation, READMEs) follows `STYLE_GUIDE.md`: documentation-reserved example values only (RFC 5737 addresses, `example.com`, RFC 5398 ASNs), never ACME, no credential material even if revoked, no real customer data, and sanitized screenshots. Run its pre-publish checklist before opening a documentation PR.
 - **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, retire your worktree, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches, leftover worktrees) unprompted — see CONTRIBUTING.md for the safe procedure.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,6 +501,17 @@ apply what fits.
 
 - Reuse existing code, patterns, and content before adding new. Do not duplicate.
 
+### Documentation content
+
+- Published content — blog articles, how-to guides, demo guides, product documentation, and
+  README files — follows `STYLE_GUIDE.md`, a managed file synced across the fleet.
+- Examples use only identifiers reserved for documentation (RFC 5737 addresses, `example.com`,
+  RFC 5398 ASNs), so content a reader copies cannot reach infrastructure we do not own. Never
+  publish credential material — including revoked or expired material — real customer data, or
+  an unsanitized screenshot.
+- Work that guide's pre-publish checklist before opening a documentation PR, and treat its
+  detection commands as a first pass rather than proof.
+
 ### Clean branches
 
 - A branch is for trial-and-error: guess, probe, refactor, and learn freely while you


### PR DESCRIPTION
Closes #743

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- CONTRIBUTING.md
- CLAUDE.md
- STYLE_GUIDE.md
- .claude/governance.json