### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -255,6 +255,12 @@
           "reason": "PII enforcement runs in an isolated hosted environment"
         }
       },
+      ".github/workflows/release-npm-backfill.yml": {
+        "backfill": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "npm backfill publication uses the hosted release environment"
+        }
+      },
       ".github/workflows/release-reconcile.yml": {
         "reconcile": {
           "runs_on": "ubuntu-22.04",


### PR DESCRIPTION
Closes #908

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/config/self-hosted-runner-policy.json