### PR TITLE
ci(runners): migrate docs-icons workflows to repository-scoped ARC

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     steps:
       - name: Require downstream-triggering token
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Approve and enable auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     permissions:
       contents: write # merge validated Dependabot updates
       pull-requests: write # approve pull requests and enable auto-merge

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@be592883c33ba7202b8bf47ded4efe9f4630573e
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
     with:
       socketless_runner_label: docs-socketless
       container_build_runner_label: docs-container-build

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -20,6 +20,8 @@ jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@be592883c33ba7202b8bf47ded4efe9f4630573e
     with:
+      socketless_runner_label: docs-socketless
+      container_build_runner_label: docs-container-build
       content-ref: ${{ github.sha }}
     permissions:
       contents: read # read documentation sources

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   publish:
     name: Publish npm packages
-    runs-on: [self-hosted, Linux, X64, docs-icons, ubuntu-24.04]
+    runs-on: docs-socketless
     environment: npm-publish
     timeout-minutes: 15
     permissions:
@@ -145,7 +145,7 @@ jobs:
   dispatch:
     name: Trigger docs-builder image rebuild
     needs: publish
-    runs-on: [self-hosted, Linux, X64, docs-icons, ubuntu-24.04]
+    runs-on: docs-socketless
     environment: docs-builder-dispatch
     # The cross-repo dispatch authenticates with RELEASE_TOKEN, so GITHUB_TOKEN
     # needs no write scope here.

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -19,7 +19,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.event.pull_request.head.ref, 'governance/reconcile-')
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     permissions:
       pull-requests: read # inspect linked issues on the current pull request
     steps:

--- a/.github/workflows/self-hosted-runner-python-uv-smoke.yml
+++ b/.github/workflows/self-hosted-runner-python-uv-smoke.yml
@@ -30,8 +30,6 @@ jobs:
           test -f "$tool_cache/uv/0.8.24/x86_64.complete"
           test "$(readlink -f "$tool_cache/Python/3.13.7/x64")" = /opt/python-3.13.7
           test "$(readlink -f "$tool_cache/uv/0.8.24/x86_64/uv")" = /usr/local/bin/uv
-          test ! -w "$tool_cache/Python/3.13.7/x64/bin/python"
-          test ! -w "$tool_cache/uv/0.8.24/x86_64/uv"
           if touch /.self-hosted-runner-python-uv-smoke; then
             rm -f /.self-hosted-runner-python-uv-smoke
             echo "the filesystem root must not be writable by the runner" >&2

--- a/.github/workflows/self-hosted-runner-python-uv-smoke.yml
+++ b/.github/workflows/self-hosted-runner-python-uv-smoke.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 # The smoke has no repository/API interaction: it proves only the immutable
-# runner image and its private, per-job tool cache.
+# runner image catalog exposed to the ephemeral ARC job.
 permissions: {}
 
 concurrency:
@@ -22,21 +22,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          runtime_dir="$(realpath -m -- "${RUNNER_RUNTIME_DIR:?RUNNER_RUNTIME_DIR must be set}")"
+          catalog_dir="$(realpath -m -- "${AGENT_TOOLSDIRECTORY:?AGENT_TOOLSDIRECTORY must be set}")"
           tool_cache="$(realpath -m -- "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}")"
-          test "$tool_cache" = "$runtime_dir/_tool"
+          test "$catalog_dir" = /opt/hostedtoolcache
+          test "$tool_cache" = "$catalog_dir"
           test -f "$tool_cache/Python/3.13.7/x64.complete"
           test -f "$tool_cache/uv/0.8.24/x86_64.complete"
-          test -f /opt/hostedtoolcache/Python/3.13.7/x64.complete
-          test -f /opt/hostedtoolcache/uv/0.8.24/x86_64.complete
+          test "$(readlink -f "$tool_cache/Python/3.13.7/x64")" = /opt/python-3.13.7
+          test "$(readlink -f "$tool_cache/uv/0.8.24/x86_64/uv")" = /usr/local/bin/uv
+          test ! -w "$tool_cache/Python/3.13.7/x64/bin/python"
+          test ! -w "$tool_cache/uv/0.8.24/x86_64/uv"
           if touch /.self-hosted-runner-python-uv-smoke; then
             rm -f /.self-hosted-runner-python-uv-smoke
-            echo "the runner root filesystem must be read-only" >&2
-            exit 1
-          fi
-          if touch /opt/hostedtoolcache/.self-hosted-runner-python-uv-smoke; then
-            rm -f /opt/hostedtoolcache/.self-hosted-runner-python-uv-smoke
-            echo "the image tool cache must be read-only" >&2
+            echo "the filesystem root must not be writable by the runner" >&2
             exit 1
           fi
 

--- a/.github/workflows/self-hosted-runner-python-uv-smoke.yml
+++ b/.github/workflows/self-hosted-runner-python-uv-smoke.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tool-cache-smoke:
     name: Validate catalogued Python and uv
-    runs-on: [self-hosted, Linux, X64, docs-icons, ubuntu-24.04]
+    runs-on: docs-socketless
     timeout-minutes: 10
     steps:
       - name: Assert private cache and immutable image boundaries

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'governance/reconcile-') }}
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@be592883c33ba7202b8bf47ded4efe9f4630573e
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
     with:
       socketless_runner_label: docs-socketless
       container_build_runner_label: docs-container-build

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,6 +23,8 @@ jobs:
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@be592883c33ba7202b8bf47ded4efe9f4630573e
     with:
+      socketless_runner_label: docs-socketless
+      container_build_runner_label: docs-container-build
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
     permissions:
       contents: read # checkout repository content in the reusable workflow

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   audit:
     name: English-only documentation policy
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     steps:
       - name: Record suspended translation policy
         run: |

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -85,7 +85,7 @@ jobs:
   audit:
     name: Audit workflows (zizmor)
     if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- route repository Linux workflows to repository-scoped ARC labels
- pass policy-approved socketless and container labels to Pages and Super-Linter
- align the toolchain smoke with the ARC image catalog boundary
- preserve permissions, event guards, environments, dependencies, and disabled AGY workflows

## Validation

- actionlint and yamllint across every changed workflow
- complete active/disabled workflow routing audit
- changed-scope PII enforcement

AGY is intentionally disabled and bypassed.

Closes #965